### PR TITLE
 feat: add card-container mixin

### DIFF
--- a/src/components/molecules/CrossChainChart/styles.scss
+++ b/src/components/molecules/CrossChainChart/styles.scss
@@ -1,20 +1,18 @@
 @import "src/styles/globals.scss";
 
 .cross-chain {
-  margin-top: 12px;
-  padding: 12px;
-  padding-bottom: 24px;
-  background: linear-gradient(to bottom, var(--color-white-05), transparent);
-  border-radius: 6px;
+  @include card-container;
 
   &-title {
     @include text-h5;
     color: var(--color-primary-50);
-    margin: 12px;
+    margin-bottom: 24px;
   }
 
   &-options {
     @include centered-row;
+
+    margin-bottom: 24px;
   }
 
   &-loader {
@@ -24,7 +22,6 @@
   }
 
   &-type {
-    padding: 12px;
     display: inline-flex;
 
     &-item {
@@ -62,7 +59,6 @@
     @include centered-row;
     display: inline-flex;
     margin-left: auto;
-    margin-right: 12px;
 
     &-text {
       @include text-p1;

--- a/src/components/molecules/VAACountChart/styles.scss
+++ b/src/components/molecules/VAACountChart/styles.scss
@@ -1,11 +1,10 @@
 @import "src/styles/globals.scss";
 
 .vaa-count {
+  @include card-container;
+
   margin-top: 24px;
   margin-bottom: 80px;
-  padding: 12px;
-  background: var(--color-white-03);
-  border-radius: 6px;
   color: var(--color-primary-500);
 
   &-title {
@@ -13,17 +12,14 @@
     font-family: "Inter", sans-serif;
     font-size: 28px;
     font-weight: 600;
-    margin: 12px;
   }
 
   &-container {
     @include centered-row;
     justify-content: center;
-    min-height: 600px;
 
     &-chart {
       width: 100%;
-      margin-left: 16px;
     }
   }
 

--- a/src/pages/Home/Statistics/index.tsx
+++ b/src/pages/Home/Statistics/index.tsx
@@ -1,0 +1,42 @@
+import "./styles.scss";
+
+const Statistics = () => {
+  return (
+    <section className="home-statistics">
+      <div className="home-statistics-graph">Graph</div>
+      <div className="home-statistics-data">
+        <div className="home-statistics-data-row">
+          <div className="home-statistics-data-row-item">
+            <div className="home-statistics-data-row-item-title">Connected chains</div>
+            <div className="home-statistics-data-row-item-value">16</div>
+          </div>
+          <div className="home-statistics-data-row-item">
+            <div className="home-statistics-data-row-item-title">All time volume</div>
+            <div className="home-statistics-data-row-item-value">$6,400,000</div>
+          </div>
+          <div className="home-statistics-data-row-item">
+            <div className="home-statistics-data-row-item-title">Total TVL</div>
+            <div className="home-statistics-data-row-item-value">$19,400,321</div>
+          </div>
+        </div>
+        <hr />
+        <div className="home-statistics-data-row">
+          <div className="home-statistics-data-row-item">
+            <div className="home-statistics-data-row-item-title">Message volume</div>
+            <div className="home-statistics-data-row-item-value">1,000,234</div>
+          </div>
+          <div className="home-statistics-data-row-item">
+            <div className="home-statistics-data-row-item-title">Assets transfer</div>
+            <div className="home-statistics-data-row-item-value">$6,400,000</div>
+          </div>
+          <div className="home-statistics-data-row-item">
+            <div className="home-statistics-data-row-item-title">Validators</div>
+            <div className="home-statistics-data-row-item-value">19</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export { Statistics };

--- a/src/pages/Home/Statistics/styles.scss
+++ b/src/pages/Home/Statistics/styles.scss
@@ -1,0 +1,54 @@
+@import "src/styles/globals.scss";
+
+.home-statistics {
+  @include centered-row;
+
+  gap: 24px;
+  margin-bottom: 24px;
+
+  > &-graph {
+    @include card-container;
+    @include centered-row;
+
+    flex: 1;
+    min-height: 256px;
+  }
+
+  > &-data {
+    @include card-container;
+    @include centered-column;
+
+    justify-content: space-between;
+    gap: 24px;
+    flex: 2;
+    min-height: 256px;
+    padding: 24px 40px;
+
+    > hr {
+      border-color: var(--color-white-10);
+    }
+
+    &-row {
+      @include centered-row;
+
+      justify-content: space-between;
+      gap: 24px;
+
+      &-item {
+        @include centered-column;
+        gap: 16px;
+        flex: 1;
+
+        &-title {
+          @include text-p1;
+          color: var(--color-primary-50);
+        }
+
+        &-value {
+          @include text-h5;
+          font-weight: 600;
+        }
+      }
+    }
+  }
+}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -2,13 +2,13 @@ import { CrossChainChart, VAACountChart } from "src/components/molecules";
 import { BaseLayout } from "src/layouts/BaseLayout";
 import { Hero } from "./Hero";
 import { JoinUs } from "./JoinUs";
+import { Statistics } from "./Statistics";
 
-type Props = {};
-
-const Home = (props: Props) => {
+const Home = () => {
   return (
     <BaseLayout>
       <Hero />
+      <Statistics />
       <CrossChainChart />
       <VAACountChart />
       <JoinUs />

--- a/src/styles/_containers.scss
+++ b/src/styles/_containers.scss
@@ -1,0 +1,5 @@
+@mixin card-container {
+  padding: 24px;
+  border-radius: 5px;
+  background-color: var(--color-white-05);
+}

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,3 +1,4 @@
+@import "containers";
 @import "breakpoints";
 @import "typography";
 @import "button";


### PR DESCRIPTION
# Description

- Add `card-container` scss mixin.
- Add `Statistics` component to the `Home` page with some hardcoded data.

<img width="915" alt="image" src="https://user-images.githubusercontent.com/25652943/220458963-a93f8de2-057a-44bd-96a1-4ea43c1fef88.png">
