### PR TITLE
Fix navigation scroll not going up

### DIFF
--- a/src/components/atoms/NavLink/index.tsx
+++ b/src/components/atoms/NavLink/index.tsx
@@ -1,0 +1,13 @@
+import { NavLink as RealNavLink, NavLinkProps } from "react-router-dom";
+
+const NavLink = (props: NavLinkProps) => {
+  const goTop = () => window.scrollTo(0, 0);
+
+  return (
+    <RealNavLink {...props} onClick={goTop}>
+      {props.children}
+    </RealNavLink>
+  );
+};
+
+export default NavLink;

--- a/src/components/atoms/index.tsx
+++ b/src/components/atoms/index.tsx
@@ -1,4 +1,5 @@
-export { default as Loader } from "./Loader";
 export { default as BlockchainIcon } from "./BlockchainIcon";
+export { default as Loader } from "./Loader";
+export { default as NavLink } from "./NavLink";
 export { default as Select } from "./Select";
 export { default as ToggleGroup } from "./ToggleGroup";

--- a/src/components/molecules/Footer/index.tsx
+++ b/src/components/molecules/Footer/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { NavLink } from "react-router-dom";
+import { NavLink } from "src/components/atoms";
 import DiscordIcon from "src/icons/DiscordIcon";
 import TwitterIcon from "src/icons/TwitterIcon";
 import WormholeBrand from "../WormholeBrand";

--- a/src/components/molecules/Header/index.tsx
+++ b/src/components/molecules/Header/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { NavLink } from "react-router-dom";
+import { NavLink } from "src/components/atoms";
 import WormholeBrand from "../WormholeBrand";
 import { HamburgerMenuIcon, Cross1Icon } from "@radix-ui/react-icons";
 import "./styles.scss";


### PR DESCRIPTION
### Description

This PR fixes a bug found by Ricardo: when switching routes, the page stays at the same scrolling position, so if you for example click on a Footer link, you go successfully to the new route, but it's like you scrolled all the way down.

With this PR, after a redirect, we will always be on top

#### BEFORE

![before](https://user-images.githubusercontent.com/41705567/228054519-3e010c9e-1eb8-4ba4-a2b5-0a0b360c1191.gif)

#### AFTER

![after](https://user-images.githubusercontent.com/41705567/228054558-4bbcbf69-ba8e-4171-ae3f-131d6de68bc9.gif)
