### PR TITLE
fix: Tx history graph should display correcto 24h

### DIFF
--- a/src/components/molecules/TransactionHistoryChart/index.tsx
+++ b/src/components/molecules/TransactionHistoryChart/index.tsx
@@ -33,19 +33,19 @@ const TransactionHistoryChart = ({ range }: Props) => {
             const date = new Date(item.time);
 
             if (range === "day") {
-              return date.toLocaleString("en-us", {
-                hour: "numeric",
-                minute: "numeric",
-                hour12: false,
+              return date.toLocaleString("en", {
+                hourCycle: "h23",
+                hour: "2-digit",
+                minute: "2-digit",
               });
             }
 
             if (range === "week") {
-              return date.toLocaleString("en-us", { weekday: "short" });
+              return date.toLocaleString("en", { weekday: "short" });
             }
 
             if (range === "month") {
-              return date.toLocaleString("en-us", { month: "short", day: "numeric" });
+              return date.toLocaleString("en", { month: "short", day: "numeric" });
             }
           }),
         );
@@ -54,7 +54,7 @@ const TransactionHistoryChart = ({ range }: Props) => {
   );
 
   // when range changes, we fetch the new range
-  useEffect(mutate, [range]);
+  useEffect(mutate, [range, mutate]);
 
   if (isError) return null;
   return (


### PR DESCRIPTION
# Description

Fixes 129

- Tx history graph now should display `00:XX` hours instead of `24:XX` hours in the tooltip.

![image](https://github.com/XLabs/wormscan-ui/assets/25652943/48d78ab5-605b-4b2b-9019-65d9de107498)

