### PR TITLE
Better mobile bottom sheet and better performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react": "18.2.0",
     "react-apexcharts": "1.4.0",
     "react-dom": "18.2.0",
+    "react-draggable": "^4.4.5",
     "react-i18next": "12.1.5",
     "react-query": "3.39.3",
     "react-router-dom": "6.7.0",

--- a/src/components/molecules/CrossChainChart/StickyInfo.tsx
+++ b/src/components/molecules/CrossChainChart/StickyInfo.tsx
@@ -1,8 +1,10 @@
 import { ChainId, CrossChainBy } from "@xlabs-libs/wormscan-sdk";
 import { formatCurrency } from "src/utils/number";
 import { Info } from "./Chart";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { BlockchainIcon } from "src/components/atoms";
+import Draggable from "react-draggable";
+import useOutsideClick from "src/utils/hooks/useOutsideClick";
 
 type Props = {
   chainName: string;
@@ -13,29 +15,74 @@ type Props = {
 
 export const StickyInfo = ({ chainName, selectedInfo, selectedType, destinations }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const stickyRef = useRef<HTMLDivElement>(null);
+
+  const mouseCanceled = useRef(false);
+
+  useOutsideClick(stickyRef, ev => {
+    if (isOpen && window.innerHeight < 1180) {
+      ev.preventDefault();
+      setIsOpen(false);
+    }
+  });
 
   return (
-    <div className="cross-chain-sticky">
+    <div className="cross-chain-sticky" ref={stickyRef}>
       <div
         className="cross-chain-sticky-container"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => {
+          if (mouseCanceled.current) {
+            mouseCanceled.current = false;
+          } else {
+            setIsOpen(true);
+          }
+        }}
         style={{
           height: isOpen ? 530 : 100,
+          cursor: isOpen ? "default" : "pointer",
         }}
       >
-        <div className="cross-chain-sticky-line">
-          <div className="cross-chain-sticky-line-draw" />
-        </div>
-        <div className="cross-chain-sticky-subtitle">Source</div>
-        <div className="cross-chain-sticky-info">
-          <span className="cross-chain-sticky-info-source">{chainName}</span>
-          <span className="cross-chain-sticky-info-value">
-            {selectedInfo?.percentage.toFixed(2)}% |{" "}
-            {selectedType === "tx"
-              ? selectedInfo.volume
-              : "$" + formatCurrency(+selectedInfo.volume, 0)}
-          </span>
-        </div>
+        <Draggable
+          axis="none"
+          disabled={!isOpen && !mouseCanceled.current}
+          position={{ x: 0, y: 2 }}
+          onStart={() => {
+            mouseCanceled.current = false;
+            setIsDragging(true);
+          }}
+          onStop={() => setIsDragging(false)}
+          onDrag={(_ev, data) => {
+            if (isDragging) {
+              if (data.y > 20) {
+                setIsOpen(false);
+                setIsDragging(false);
+                mouseCanceled.current = true;
+              }
+              if (data.y < -20) {
+                setIsOpen(true);
+                setIsDragging(false);
+              }
+            }
+          }}
+        >
+          <div style={{ cursor: isOpen ? "grab" : "pointer" }}>
+            <div className="cross-chain-sticky-line">
+              <div className="cross-chain-sticky-line-draw" />
+            </div>
+
+            <div className="cross-chain-sticky-subtitle">Source</div>
+            <div className="cross-chain-sticky-info">
+              <span className="cross-chain-sticky-info-source">{chainName}</span>
+              <span className="cross-chain-sticky-info-value">
+                {selectedInfo?.percentage.toFixed(2)}% |{" "}
+                {selectedType === "tx"
+                  ? selectedInfo.volume
+                  : "$" + formatCurrency(+selectedInfo.volume, 0)}
+              </span>
+            </div>
+          </div>
+        </Draggable>
 
         <div className="cross-chain-sticky-destinations" style={{ opacity: isOpen ? 1 : 0 }}>
           <div className="cross-chain-sticky-separator" />

--- a/src/utils/hooks/useOutsideClick.ts
+++ b/src/utils/hooks/useOutsideClick.ts
@@ -1,0 +1,26 @@
+import { RefObject, useCallback, useEffect } from "react";
+
+type CallbackType = (event?: MouseEvent | TouchEvent) => void;
+
+const useOutsideClick = (ref: RefObject<HTMLElement>, callback: CallbackType): void => {
+  const handleClick = useCallback(
+    (event: MouseEvent | TouchEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback(event);
+      }
+    },
+    [callback, ref],
+  );
+
+  useEffect(() => {
+    document.addEventListener("touchstart", handleClick, { passive: false });
+    document.addEventListener("mousedown", handleClick, { passive: false });
+
+    return () => {
+      document.removeEventListener("touchstart", handleClick);
+      document.removeEventListener("mousedown", handleClick);
+    };
+  }, [handleClick]);
+};
+
+export default useOutsideClick;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4426,6 +4426,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clsx@npm:^1.1.1":
+  version: 1.2.1
+  resolution: "clsx@npm:1.2.1"
+  checksum: 30befca8019b2eb7dbad38cff6266cf543091dae2825c856a62a8ccf2c3ab9c2907c4d12b288b73101196767f66812365400a227581484a05f968b0307cfaf12
+  languageName: node
+  linkType: hard
+
 "color-convert@npm:^1.9.0":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
@@ -8434,6 +8441,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-draggable@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "react-draggable@npm:4.4.5"
+  dependencies:
+    clsx: ^1.1.1
+    prop-types: ^15.8.1
+  peerDependencies:
+    react: ">= 16.3.0"
+    react-dom: ">= 16.3.0"
+  checksum: 21c3775db086e13020967627c20acd41d1ddbc7c7d7fca51491a5bbb54a0aa7e1730a4bc9af17141eb50a4954e547a5e25b2368f5f54b70db6f2686a897bacf2
+  languageName: node
+  linkType: hard
+
 "react-error-overlay@npm:6.0.9":
   version: 6.0.9
   resolution: "react-error-overlay@npm:6.0.9"
@@ -10113,6 +10133,7 @@ __metadata:
     react: 18.2.0
     react-apexcharts: 1.4.0
     react-dom: 18.2.0
+    react-draggable: ^4.4.5
     react-i18next: 12.1.5
     react-query: 3.39.3
     react-router-dom: 6.7.0


### PR DESCRIPTION
### Changes Done

- Changed the sankey chart from an animation to a fixed image (with this, the sankey chart looks amazing on every device without compromising performance as it was before).
- Did the requested changes for the bottom sheet mobile component.

--

Those bottom sheet changes are the following:
- It is now draggable down for it to be closed.
- It doesn't close if you press on it while its open anymore, it now closes when you press outside of it while open.

https://github.com/XLabs/wormscan-ui/assets/41705567/8fa140ee-a712-457b-9796-5c12b7d22268

- If the device is a big device where the bottom sheet can be shown at full along the sankey chart at full (like an iPad Air or a non-fullscreen desktop), it wont close when yo press outside of it (because you can use the vertical space to see it all really easily)

https://github.com/XLabs/wormscan-ui/assets/41705567/ac00e943-fd32-4410-a169-d4dc05be2340


