### PR TITLE
Improve Cross Chain Chart for testnet and small desktops

### DIFF
--- a/src/components/molecules/CrossChainChart/Chart.tsx
+++ b/src/components/molecules/CrossChainChart/Chart.tsx
@@ -193,7 +193,7 @@ export const Chart = ({ data, selectedType }: Props) => {
                 marginBottom: MARGIN_SIZE_ELEMENTS,
               }}
             >
-              <div data-selected={selectedChain === item.chain} className="volume-tooltip">
+              <div data-selected={selectedChain === item.chain} className="volume-info">
                 {getAmount(item.volume)}
               </div>
               <BlockchainIcon className="chain-icon" dark={true} size={19} chainId={item.chain} />
@@ -223,7 +223,7 @@ export const Chart = ({ data, selectedType }: Props) => {
                 marginBottom: MARGIN_SIZE_ELEMENTS,
               }}
             >
-              <div data-selected={true} className="volume-tooltip">
+              <div data-selected={true} className="volume-info">
                 {getAmount(item.volume)}
               </div>
               <BlockchainIcon className="chain-icon" dark={true} size={19} chainId={item.chain} />

--- a/src/components/molecules/CrossChainChart/Chart.tsx
+++ b/src/components/molecules/CrossChainChart/Chart.tsx
@@ -6,6 +6,7 @@ import { useWindowSize } from "src/utils/hooks/useWindowSize";
 import { useTranslation } from "react-i18next";
 import { BREAKPOINTS } from "src/consts";
 import { StickyInfo } from "./StickyInfo";
+import { getCurrentNetwork } from "src/api/Client";
 
 interface IOriginChainsHeight {
   itemHeight: number;
@@ -133,13 +134,12 @@ export const Chart = ({ data, selectedType }: Props) => {
     );
   };
 
-  // chart graph creation effect, runs as an animation
+  // chart graph creation effect
   useEffect(() => {
     if (originChainsHeight.length && destinyChainsHeight.length) {
       const canvas = canvasRef.current;
       const context = canvas.getContext("2d");
 
-      // prevent pixelated canvas on high quality resolution devices
       canvas.width = Math.floor(CHART_SIZE * devicePixelRatio);
       canvas.height = Math.floor(CHART_SIZE * devicePixelRatio);
       context.scale(devicePixelRatio, devicePixelRatio);
@@ -170,6 +170,9 @@ export const Chart = ({ data, selectedType }: Props) => {
   // re-render canvas when destinations or isDesktop changes.
   useEffect(updateChainsHeight, [destinations, isDesktop]);
 
+  const getAmount = (vol: string | number) =>
+    selectedType === "tx" ? vol : "$" + formatCurrency(+vol, 0);
+
   return (
     <div className="cross-chain-relative">
       <div className="cross-chain-header-container cross-chain-header-title">
@@ -190,14 +193,15 @@ export const Chart = ({ data, selectedType }: Props) => {
                 marginBottom: MARGIN_SIZE_ELEMENTS,
               }}
             >
+              <div data-selected={selectedChain === item.chain} className="volume-tooltip">
+                {getAmount(item.volume)}
+              </div>
               <BlockchainIcon className="chain-icon" dark={true} size={19} chainId={item.chain} />
               <span className="chain-name">{getChainName(item.chain)}</span>
               {!isDesktop && <span className="mobile-separator">|</span>}
               <span className="chain-infoTxt percentage">{item.percentage.toFixed(2)}%</span>
               <span className="chain-separator onlyBig">|</span>
-              <span className="chain-infoTxt onlyBig">
-                {selectedType === "tx" ? item.volume : "$" + formatCurrency(+item.volume, 0)}
-              </span>
+              <span className="chain-infoTxt onlyBig">{getAmount(item.volume)}</span>
             </div>
           ))}
         </div>
@@ -219,14 +223,15 @@ export const Chart = ({ data, selectedType }: Props) => {
                 marginBottom: MARGIN_SIZE_ELEMENTS,
               }}
             >
+              <div data-selected={true} className="volume-tooltip">
+                {getAmount(item.volume)}
+              </div>
               <BlockchainIcon className="chain-icon" dark={true} size={19} chainId={item.chain} />
               <span className="chain-name">{getChainName(item.chain)}</span>
               {!isDesktop && <span className="mobile-separator">|</span>}
               <span className="chain-infoTxt percentage">{item.percentage.toFixed(2)}%</span>
               <span className="chain-separator onlyBig">|</span>
-              <span className="chain-infoTxt onlyBig">
-                {selectedType === "tx" ? item.volume : "$" + formatCurrency(+item.volume, 0)}
-              </span>
+              <span className="chain-infoTxt onlyBig">{getAmount(item.volume)}</span>
             </div>
           ))}
         </div>

--- a/src/components/molecules/CrossChainChart/index.tsx
+++ b/src/components/molecules/CrossChainChart/index.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { getClient } from "src/api/Client";
+import { useEffect, useState } from "react";
+import { getClient, getCurrentNetwork } from "src/api/Client";
 import { Chart } from "./Chart";
 import { useQuery } from "react-query";
 import { Loader, Select, ToggleGroup } from "src/components/atoms";
@@ -9,8 +9,12 @@ import { CrossChainBy } from "@xlabs-libs/wormscan-sdk";
 import { ErrorPlaceholder } from "src/components/molecules";
 import "./styles.scss";
 
-const TYPE_LIST = [
+const MAINNET_TYPE_LIST = [
   { label: i18n.t("home.crossChain.volume"), value: "notional", ariaLabel: "Volume" },
+  { label: i18n.t("home.crossChain.count"), value: "tx", ariaLabel: "Transactions" },
+];
+
+const TESTNET_TYPE_LIST = [
   { label: i18n.t("home.crossChain.count"), value: "tx", ariaLabel: "Transactions" },
 ];
 
@@ -23,10 +27,21 @@ const RANGE_LIST = [
 ];
 
 const CrossChainChart = () => {
+  const currentNetwork = getCurrentNetwork();
   const { t } = useTranslation();
 
+  const [TYPE_LIST, setTypeList] = useState(MAINNET_TYPE_LIST);
   const [selectedType, setSelectedType] = useState<CrossChainBy>("notional");
   const [selectedTimeRange, setSelectedTimeRange] = useState(RANGE_LIST[0]);
+
+  useEffect(() => {
+    if (currentNetwork === "mainnet") {
+      setTypeList(MAINNET_TYPE_LIST);
+    } else {
+      setSelectedType("tx");
+      setTypeList(TESTNET_TYPE_LIST);
+    }
+  }, [currentNetwork]);
 
   const { data, isError, isLoading, isFetching } = useQuery(
     ["getLastTxs", selectedType, selectedTimeRange.value],

--- a/src/components/molecules/CrossChainChart/styles.scss
+++ b/src/components/molecules/CrossChainChart/styles.scss
@@ -111,6 +111,7 @@
         grid-auto-flow: column;
         align-items: center;
         border-left: 16px solid var(--color-information-60);
+        position: relative;
 
         grid-template-columns: 70px 60px;
 
@@ -229,8 +230,31 @@
           }
         }
 
+        .volume-tooltip {
+          display: none;
+          position: absolute;
+          z-index: 2;
+          padding-left: 8px;
+          padding-right: 8px;
+          font-size: 14px;
+          height: 20px;
+
+          @include desktop {
+            &[data-selected="true"] {
+              display: block;
+            }
+          }
+          @include bigDesktop {
+            display: none !important;
+          }
+        }
+
         &.left {
           cursor: pointer;
+
+          .volume-tooltip {
+            left: 100%;
+          }
 
           .chain-name {
             margin-left: 5px;
@@ -243,6 +267,9 @@
         &.right {
           .percentage {
             display: block;
+          }
+          .volume-tooltip {
+            right: 100%;
           }
           .mobile-separator {
             @media only screen and (min-width: 425px) {

--- a/src/components/molecules/CrossChainChart/styles.scss
+++ b/src/components/molecules/CrossChainChart/styles.scss
@@ -230,7 +230,7 @@
           }
         }
 
-        .volume-tooltip {
+        .volume-info {
           display: none;
           position: absolute;
           z-index: 2;
@@ -252,7 +252,7 @@
         &.left {
           cursor: pointer;
 
-          .volume-tooltip {
+          .volume-info {
             left: 100%;
           }
 
@@ -268,7 +268,7 @@
           .percentage {
             display: block;
           }
-          .volume-tooltip {
+          .volume-info {
             right: 100%;
           }
           .mobile-separator {


### PR DESCRIPTION
### Description

This PR
- Fixes the following bug: #161 .
- Removes the "Volume" tab on testnet because testnet assets are not worth money (only transaction available now).
- Adds the volume data for small desktop devices that were not able to see that data (>1024px & <1440px)

### Screenshot

![screenshot](https://github.com/XLabs/wormscan-ui/assets/41705567/f3fdc5aa-4cae-4bb7-9396-a830e5920666)

