### PR TITLE
Fix testnet explorers and total guardians

### DIFF
--- a/src/pages/Tx/Information/Overview/index.tsx
+++ b/src/pages/Tx/Information/Overview/index.tsx
@@ -19,10 +19,7 @@ import { useWindowSize } from "src/utils/hooks/useWindowSize";
 import { BREAKPOINTS, colorStatus } from "src/consts";
 import { parseTx, parseAddress } from "../../../../utils/crypto";
 import "./styles.scss";
-
-// 360 degree / 19 total signatures
-// A fraction of 360 degrees (360 / 13) = 27.7 est.
-const FRACTION_DEGREE = 27.7;
+import { getCurrentNetwork } from "src/api/Client";
 
 type Props = {
   VAAData: Omit<VAADetail, "vaa"> & { vaa: any };
@@ -47,6 +44,10 @@ const Overview = ({
   tokenDataResponse,
   tokenPriceResponse,
 }: Props) => {
+  const currentNetwork = getCurrentNetwork();
+  const totalGuardiansNeeded = currentNetwork === "mainnet" ? 13 : 1;
+  const FRACTION_DEGREE = 360 / totalGuardiansNeeded;
+
   const size = useWindowSize();
   const isMobile = size.width < BREAKPOINTS.tablet;
   const { emitterNativeAddr, emitterChainId, payload, vaa } = VAAData || {};
@@ -61,8 +62,9 @@ const Overview = ({
   const signatureContainerMaskDegree = Math.abs(
     360 - (360 - guardianSignaturesCount * FRACTION_DEGREE),
   );
-  const signatureStyles: CSSProperties & { "--m2": string } = {
+  const signatureStyles: CSSProperties & { "--m2": string; "--n": number } = {
     "--m2": `calc(${signatureContainerMaskDegree}deg)`,
+    "--n": totalGuardiansNeeded, // number of dashes
   };
   const { id: VAAId, originTx, destinationTx } = globalTxData || {};
   const {
@@ -234,7 +236,7 @@ const Overview = ({
               <div className="tx-overview-graph-step-signaturesContainer-circle"></div>
               <div className="tx-overview-graph-step-signaturesContainer-text">
                 <div className="tx-overview-graph-step-signaturesContainer-text-number">
-                  {guardianSignaturesCount}/13
+                  {guardianSignaturesCount}/{totalGuardiansNeeded}
                 </div>
                 <div className="tx-overview-graph-step-signaturesContainer-text-description">
                   Signatures

--- a/src/pages/Tx/Information/Overview/styles.scss
+++ b/src/pages/Tx/Information/Overview/styles.scss
@@ -200,7 +200,6 @@
 
       &-signaturesContainer {
         --d: 5deg; /* distance between dashes */
-        --n: 13; /* number of dashes */
         --c: var(--color-success-100); /* color of dashes */
         --b: 8px; /* control the thickness of border*/
         --m: 0deg; /* the masked part */

--- a/src/utils/wormhole.ts
+++ b/src/utils/wormhole.ts
@@ -54,6 +54,7 @@ import SeiDarkIcon from "src/icons/blockchains/dark/sei.svg";
 
 import { parseAddress, parseTx } from "./crypto";
 import { NETWORK } from "src/types";
+import { getCurrentNetwork } from "src/api/Client";
 
 export type ExplorerBaseURLInput = {
   network: NETWORK;
@@ -412,11 +413,14 @@ const WORMHOLE_CHAINS: { [key in ChainId]: any } = {
       mainnet: "https://solscan.io",
     },
     getExplorerBaseURL: function ({ network = "mainnet", value, base }: ExplorerBaseURLInput) {
+      // Wormhole uses Solana's devnet as their 'testnet'
+      const solNetwork = network === "mainnet" ? "mainnet" : "devnet";
+
       if (base === "address")
-        return this.explorer?.[network] + "/account/" + value + "?cluster=" + network;
+        return this.explorer?.[network] + "/account/" + value + "?cluster=" + solNetwork;
       if (base === "token")
-        return this.explorer?.[network] + "/token/" + value + "?cluster=" + network;
-      return this.explorer?.[network] + "/tx/" + value + "?cluster=" + network;
+        return this.explorer?.[network] + "/token/" + value + "?cluster=" + solNetwork;
+      return this.explorer?.[network] + "/tx/" + value + "?cluster=" + solNetwork;
     },
   },
   [ChainId.Terra]: {
@@ -509,7 +513,7 @@ export const getExplorerLink = ({
   base?: "tx" | "address" | "token";
   isNativeAddress?: boolean;
 }): string => {
-  const network = "mainnet";
+  const network = getCurrentNetwork();
   let parsedValue = value;
 
   if (!isNativeAddress) {


### PR DESCRIPTION
### Description

When being on testnet on wormscan and pressing any address on the transaction list, it opened the explorer for that address/transaction on the mainnet explorer instead of the testnet one. Fixed.

Also, on testnet there is only one guardian, so all the completed transactions were showing "1/13" guardian signatures. Fixed that and now we show 1/1 guardian signatures on testnet.

### Screenshot

![TestNet](https://github.com/XLabs/wormscan-ui/assets/41705567/79a8f2d2-fa86-4bab-b22c-175595d4f511)

