### PR TITLE
Add pagination to CrossChainChart to see every chain info

### DIFF
--- a/src/components/atoms/Pagination/index.tsx
+++ b/src/components/atoms/Pagination/index.tsx
@@ -26,27 +26,33 @@ const Pagination = ({
   const isFirstPage = currentPage === 1;
   const isLastPage = currentPage === totalPages;
 
-  // Note: goLastPage button is disabled due to API limitation
-
   return (
     <div className={`pagination ${className}`}>
-      <button onClick={goFirstPage} disabled={disabled || isFirstPage}>
-        &lt;&lt;
-      </button>
+      {goFirstPage && (
+        <button onClick={goFirstPage} disabled={disabled || isFirstPage}>
+          &lt;&lt;
+        </button>
+      )}
+
       <button onClick={goPrevPage} disabled={disabled || isFirstPage}>
         &lt;
       </button>
+
       <span className="pagination-current">{currentPage}</span>
+
       <button onClick={goNextPage} disabled={disabled || disableNextButton || isLastPage}>
         &gt;
       </button>
-      <button
-        className="pagination-last-page"
-        onClick={goLastPage}
-        disabled={disabled || true || isLastPage}
-      >
-        &gt;&gt;
-      </button>
+
+      {goLastPage && (
+        <button
+          className="pagination-last-page"
+          onClick={goLastPage}
+          disabled={disabled || true || isLastPage}
+        >
+          &gt;&gt;
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/atoms/Pagination/styles.scss
+++ b/src/components/atoms/Pagination/styles.scss
@@ -37,6 +37,9 @@
 
   & > button:hover {
     background: var(--color-white-10);
+    &:disabled {
+      background: none;
+    }
   }
 
   & > button:active {
@@ -46,6 +49,7 @@
 
   & > *:disabled {
     color: var(--color-white-20);
+    cursor: not-allowed;
   }
 
   &-current {

--- a/src/components/molecules/CrossChainChart/Chart.tsx
+++ b/src/components/molecules/CrossChainChart/Chart.tsx
@@ -1,6 +1,6 @@
 import { ChainId, CrossChainActivity, CrossChainBy } from "@xlabs-libs/wormscan-sdk";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { BlockchainIcon } from "src/components/atoms";
+import { BlockchainIcon, Pagination } from "src/components/atoms";
 import { formatCurrency } from "src/utils/number";
 import { useWindowSize } from "src/utils/hooks/useWindowSize";
 import { useTranslation } from "react-i18next";
@@ -181,9 +181,9 @@ export const Chart = ({ data, selectedType }: Props) => {
 
   return (
     <div className="cross-chain-relative">
-      <div className="cross-chain-header-container cross-chain-header-title">
-        <div>{t("home.crossChain.source")}</div>
-        <div>{t("home.crossChain.destination")}</div>
+      <div className="cross-chain-header-container title">
+        <div>{t("home.crossChain.source").toUpperCase()}</div>
+        <div>{t("home.crossChain.destination").toUpperCase()}</div>
       </div>
       <div className="cross-chain-chart">
         <div className="cross-chain-chart-side" ref={originChainsRef}>
@@ -243,7 +243,7 @@ export const Chart = ({ data, selectedType }: Props) => {
         </div>
       </div>
 
-      <div
+      {/* <div
         style={{
           opacity: selectedChain === OTHERS_FAKE_CHAIN_ID || isShowingOthers ? 1 : 0,
           cursor: selectedChain === OTHERS_FAKE_CHAIN_ID || isShowingOthers ? "pointer" : "default",
@@ -251,10 +251,10 @@ export const Chart = ({ data, selectedType }: Props) => {
         onClick={() => {
           if (selectedChain === OTHERS_FAKE_CHAIN_ID) {
             setChartData(processData(data, true));
-            setIsShowingOthers(true);
+            // setIsShowingOthers(true);
           }
           if (isShowingOthers) {
-            setIsShowingOthers(false);
+            // setIsShowingOthers(false);
             const processedData = processData(data, false);
             setChartData(processedData);
             setSelectedChain(processedData[9].chain);
@@ -263,7 +263,21 @@ export const Chart = ({ data, selectedType }: Props) => {
         className="chain-others"
       >
         {isShowingOthers ? "Back to top 10 chains" : "Show other chain details"}
-      </div>
+      </div> */}
+
+      <Pagination
+        className="cross-chain-relative-pagination"
+        currentPage={isShowingOthers ? 2 : 1}
+        goNextPage={() => {
+          setIsShowingOthers(true);
+          setChartData(processData(data, true));
+        }}
+        goPrevPage={() => {
+          setIsShowingOthers(false);
+          setChartData(processData(data, false));
+        }}
+        disableNextButton={isShowingOthers}
+      />
 
       <StickyInfo
         chainName={getChainName(selectedChain)}
@@ -284,53 +298,55 @@ const getChainName = (id: ChainId) => {
 const processData = (data: CrossChainActivity, showOthers: boolean) => {
   const newData = [...data].sort((a, b) => b.percentage - a.percentage);
 
-  // if more than 10 elements, create "Others" section
-  if (!showOthers && newData.length > 10) {
-    let percentage = 0;
-    let volume = 0;
-    const destinations: any = {};
-
-    newData.slice(10).forEach(item => {
-      // sum the percentage and volume of every other chain
-      percentage += item.percentage;
-      volume += +item.volume;
-
-      // create an object that sums the volume for the same destiny chain
-      item.destinations.forEach(destination => {
-        destinations[destination.chain] = {
-          volume: (destinations[destination.chain]?.volume ?? 0) + Number(destination.volume),
-        };
-      });
-    });
-
-    // transform the object with destination volumes summed up into an array of chains
-    let newDestinations = [];
-    for (const [chain, value] of Object.entries(destinations) as any) {
-      newDestinations.push({
-        chain,
-        volume: value.volume,
-      });
-    }
-
-    // add percentages to that array of destination chains
-    let totalVolume = 0;
-    newDestinations.forEach(dest => {
-      totalVolume += dest.volume;
-    });
-    newDestinations = newDestinations.map(dest => ({
-      chain: dest.chain,
-      volume: dest.volume,
-      percentage: (dest.volume / totalVolume) * 100,
-    }));
-
-    // sort the array and use only the first 10 elements
-    newDestinations = newDestinations.sort((a: any, b: any) => b.volume - a.volume).slice(0, 10);
-    newData[9] = { chain: OTHERS_FAKE_CHAIN_ID, percentage, volume, destinations: newDestinations };
-
-    return newData.slice(0, 10);
-  }
-
   if (showOthers) {
     return newData.slice(10);
   }
+
+  return newData.slice(0, 10);
+
+  // if more than 10 elements, create "Others" section
+  // if (!showOthers && newData.length > 10) {
+  //   let percentage = 0;
+  //   let volume = 0;
+  //   const destinations: any = {};
+
+  //   newData.slice(10).forEach(item => {
+  //     // sum the percentage and volume of every other chain
+  //     percentage += item.percentage;
+  //     volume += +item.volume;
+
+  //     // create an object that sums the volume for the same destiny chain
+  //     item.destinations.forEach(destination => {
+  //       destinations[destination.chain] = {
+  //         volume: (destinations[destination.chain]?.volume ?? 0) + Number(destination.volume),
+  //       };
+  //     });
+  //   });
+
+  //   // transform the object with destination volumes summed up into an array of chains
+  //   let newDestinations = [];
+  //   for (const [chain, value] of Object.entries(destinations) as any) {
+  //     newDestinations.push({
+  //       chain,
+  //       volume: value.volume,
+  //     });
+  //   }
+
+  //   // add percentages to that array of destination chains
+  //   let totalVolume = 0;
+  //   newDestinations.forEach(dest => {
+  //     totalVolume += dest.volume;
+  //   });
+  //   newDestinations = newDestinations.map(dest => ({
+  //     chain: dest.chain,
+  //     volume: dest.volume,
+  //     percentage: (dest.volume / totalVolume) * 100,
+  //   }));
+
+  //   // sort the array and use only the first 10 elements
+  //   newDestinations = newDestinations.sort((a: any, b: any) => b.volume - a.volume).slice(0, 10);
+  //   newData[9] = { chain: OTHERS_FAKE_CHAIN_ID, percentage, volume, destinations: newDestinations };
+
+  //   return newData.slice(0, 10);
+  // }
 };

--- a/src/components/molecules/CrossChainChart/Chart.tsx
+++ b/src/components/molecules/CrossChainChart/Chart.tsx
@@ -243,28 +243,6 @@ export const Chart = ({ data, selectedType }: Props) => {
         </div>
       </div>
 
-      {/* <div
-        style={{
-          opacity: selectedChain === OTHERS_FAKE_CHAIN_ID || isShowingOthers ? 1 : 0,
-          cursor: selectedChain === OTHERS_FAKE_CHAIN_ID || isShowingOthers ? "pointer" : "default",
-        }}
-        onClick={() => {
-          if (selectedChain === OTHERS_FAKE_CHAIN_ID) {
-            setChartData(processData(data, true));
-            // setIsShowingOthers(true);
-          }
-          if (isShowingOthers) {
-            // setIsShowingOthers(false);
-            const processedData = processData(data, false);
-            setChartData(processedData);
-            setSelectedChain(processedData[9].chain);
-          }
-        }}
-        className="chain-others"
-      >
-        {isShowingOthers ? "Back to top 10 chains" : "Show other chain details"}
-      </div> */}
-
       <Pagination
         className="cross-chain-relative-pagination"
         currentPage={isShowingOthers ? 2 : 1}
@@ -298,55 +276,5 @@ const getChainName = (id: ChainId) => {
 const processData = (data: CrossChainActivity, showOthers: boolean) => {
   const newData = [...data].sort((a, b) => b.percentage - a.percentage);
 
-  if (showOthers) {
-    return newData.slice(10);
-  }
-
-  return newData.slice(0, 10);
-
-  // if more than 10 elements, create "Others" section
-  // if (!showOthers && newData.length > 10) {
-  //   let percentage = 0;
-  //   let volume = 0;
-  //   const destinations: any = {};
-
-  //   newData.slice(10).forEach(item => {
-  //     // sum the percentage and volume of every other chain
-  //     percentage += item.percentage;
-  //     volume += +item.volume;
-
-  //     // create an object that sums the volume for the same destiny chain
-  //     item.destinations.forEach(destination => {
-  //       destinations[destination.chain] = {
-  //         volume: (destinations[destination.chain]?.volume ?? 0) + Number(destination.volume),
-  //       };
-  //     });
-  //   });
-
-  //   // transform the object with destination volumes summed up into an array of chains
-  //   let newDestinations = [];
-  //   for (const [chain, value] of Object.entries(destinations) as any) {
-  //     newDestinations.push({
-  //       chain,
-  //       volume: value.volume,
-  //     });
-  //   }
-
-  //   // add percentages to that array of destination chains
-  //   let totalVolume = 0;
-  //   newDestinations.forEach(dest => {
-  //     totalVolume += dest.volume;
-  //   });
-  //   newDestinations = newDestinations.map(dest => ({
-  //     chain: dest.chain,
-  //     volume: dest.volume,
-  //     percentage: (dest.volume / totalVolume) * 100,
-  //   }));
-
-  //   // sort the array and use only the first 10 elements
-  //   newDestinations = newDestinations.sort((a: any, b: any) => b.volume - a.volume).slice(0, 10);
-  //   newData[9] = { chain: OTHERS_FAKE_CHAIN_ID, percentage, volume, destinations: newDestinations };
-
-  //   return newData.slice(0, 10);
-  // }
+  return showOthers ? newData.slice(10) : newData.slice(0, 10);
 };

--- a/src/components/molecules/CrossChainChart/styles.scss
+++ b/src/components/molecules/CrossChainChart/styles.scss
@@ -6,6 +6,10 @@
 
   &-relative {
     position: relative;
+
+    &-pagination {
+      margin-top: 16px;
+    }
   }
 
   &-title {
@@ -105,7 +109,7 @@
         color: var(--color-white);
         user-select: none;
         width: 100%;
-        min-height: 30px;
+        min-height: 24px;
         display: grid;
         grid-auto-flow: column;
         align-items: center;
@@ -127,7 +131,7 @@
           grid-template-columns: 1.5fr 5fr 1fr;
           background: withOpacity(var(--color-primary-100), 0.2);
           border-left: 0;
-          min-height: 20px;
+          // min-height: 20px;
         }
         @include bigDesktop {
           grid-template-columns: 1.2fr 3.6fr 2fr 0.2fr 4fr;
@@ -163,7 +167,6 @@
 
         .chain-icon {
           justify-self: center;
-          transform: translateY(-1.5px);
           display: none;
           @include desktop {
             display: block;
@@ -466,5 +469,9 @@
 
     color: var(--color-primary-100);
     @include text-p3;
+
+    &.title {
+      font-weight: 500;
+    }
   }
 }

--- a/src/components/molecules/CrossChainChart/styles.scss
+++ b/src/components/molecules/CrossChainChart/styles.scss
@@ -131,7 +131,6 @@
           grid-template-columns: 1.5fr 5fr 1fr;
           background: withOpacity(var(--color-primary-100), 0.2);
           border-left: 0;
-          // min-height: 20px;
         }
         @include bigDesktop {
           grid-template-columns: 1.2fr 3.6fr 2fr 0.2fr 4fr;

--- a/src/components/molecules/CrossChainChart/styles.scss
+++ b/src/components/molecules/CrossChainChart/styles.scss
@@ -337,6 +337,17 @@
     }
   }
 
+  .chain-others {
+    width: max(25%, 200px);
+    background-color: #00005070;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 2px;
+    transition: opacity 0.25s ease-out;
+  }
+
   &-sticky {
     display: block;
     position: sticky;
@@ -437,7 +448,7 @@
 
   &-message {
     display: flex;
-    margin-top: 24px;
+    margin-top: 12px;
     flex-direction: column;
 
     @include text-p3;

--- a/src/components/molecules/CrossChainChart/styles.scss
+++ b/src/components/molecules/CrossChainChart/styles.scss
@@ -339,17 +339,6 @@
     }
   }
 
-  .chain-others {
-    width: max(25%, 200px);
-    background-color: #00005070;
-    height: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: 2px;
-    transition: opacity 0.25s ease-out;
-  }
-
   &-sticky {
     display: block;
     position: sticky;


### PR DESCRIPTION
### Description

This PR implements pagination on the cross chain activity chart for users to be able to see the transactions/volume information for every chain including the small ones instead of only the top 10 ones

### Screenshot

![crossChain](https://github.com/XLabs/wormscan-ui/assets/41705567/1d970b50-1955-49cc-9aa2-2e4131f3e136)
