### PR TITLE
Fix two navigation feedbacks

### DIFF
--- a/src/components/molecules/Header/index.tsx
+++ b/src/components/molecules/Header/index.tsx
@@ -8,8 +8,9 @@ import Search from "./Search";
 import { PORTAL_BRIDGE_URL } from "src/consts";
 import { changeNetwork } from "src/api/Client";
 import { NETWORK } from "src/types";
-import { useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import "./styles.scss";
+import { useNavigateCustom } from "src/utils/hooks/useNavigateCustom";
 
 const setOverflowHidden = (hidden: boolean) => {
   if (hidden) {
@@ -52,6 +53,8 @@ const getCurrentNetworkItem = (network: NETWORK): NetworkSelectProps => {
 
 const Header = ({ network }: Props) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
   const [, setSearchParams] = useSearchParams();
   const [selectedNetwork, setSelectedNetwork] = useState<NetworkSelectProps>(
     getCurrentNetworkItem(network),
@@ -78,6 +81,18 @@ const Header = ({ network }: Props) => {
   }, [network]);
 
   const onClickChangeNetwork = (network: NETWORK) => {
+    if (network === selectedNetwork.value) return;
+
+    if (pathname.includes("/tx/")) {
+      navigate(`/txs?network=${network}`);
+      return;
+    }
+
+    if (pathname.includes("/search-not-found")) {
+      navigate(`/?network=${network}`);
+      return;
+    }
+
     setSearchParams(prev => {
       prev.set("network", network);
       return prev;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8597,7 +8597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-draggable@npm:^4.4.5":
+"react-draggable@npm:4.4.5":
   version: 4.4.5
   resolution: "react-draggable@npm:4.4.5"
   dependencies:
@@ -10294,7 +10294,7 @@ __metadata:
     react: 18.2.0
     react-apexcharts: 1.4.0
     react-dom: 18.2.0
-    react-draggable: ^4.4.5
+    react-draggable: 4.4.5
     react-i18next: 12.1.5
     react-query: 3.39.3
     react-router-dom: 6.7.0


### PR DESCRIPTION
### Before

- If I was on the details of a transaction on mainnet and selected mainnet on the network selector, the page was getting stuck on a infinite loader, and, if I selected testnet, it tried to search for the same txHash on testnet (which its never going to be found)
- If I was on the 'search not found' page and I switched network, the search not found page was refreshed but on the different network

https://github.com/XLabs/wormscan-ui/assets/41705567/4ce1cbf8-6650-4b4b-ab89-ead607f7e89f

### After

- If I'm on the details of a transaction on mainnet and select mainnet, nothing happens. And if I select testnet, it moves the user to the transactions list.
- If I'm on the 'search not found' page and I switch network, It moves me to the home.

https://github.com/XLabs/wormscan-ui/assets/41705567/76cb0f46-de09-4ecb-bd9a-965705bd84e4

