### PR TITLE
Fix/search by vaa id support

### DIFF
--- a/src/components/molecules/Header/Search/index.tsx
+++ b/src/components/molecules/Header/Search/index.tsx
@@ -94,10 +94,10 @@ const Search = () => {
     },
     {
       onSuccess: vaa => {
-        if ("txHash" in vaa) {
-          const { id: VAAId, txHash } = vaa || {};
+        if ("id" in vaa) {
+          const { id: VAAId } = vaa || {};
 
-          if (txHash) {
+          if (VAAId) {
             queryClient.setQueryData(["getVAA", VAAId], vaa);
             navigate(`/tx/${VAAId}`);
           } else {

--- a/src/components/molecules/Header/Search/index.tsx
+++ b/src/components/molecules/Header/Search/index.tsx
@@ -61,7 +61,7 @@ const Search = () => {
       onSuccess: vaa => {
         const { txHash } = vaa || {};
         if (txHash) {
-          queryClient.setQueryData(["getVAA", txHash], vaa);
+          queryClient.setQueryData(["getVAAbyTxHash", txHash], vaa);
           navigate(`/tx/${txHash}`);
         } else {
           goSearchNotFound();
@@ -95,11 +95,11 @@ const Search = () => {
     {
       onSuccess: vaa => {
         if ("txHash" in vaa) {
-          const { txHash } = vaa || {};
+          const { id: VAAId, txHash } = vaa || {};
 
           if (txHash) {
-            queryClient.setQueryData(["getVAA", txHash], vaa);
-            navigate(`/tx/${txHash}`);
+            queryClient.setQueryData(["getVAA", VAAId], vaa);
+            navigate(`/tx/${VAAId}`);
           } else {
             goSearchNotFound();
           }

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -24,6 +24,7 @@ const Navigation = () => {
           <Route path="/" element={<Home />} />
           <Route path="/txs" element={<Txs />} />
           <Route path="/tx/:txHash" element={<Tx />} />
+          <Route path="/tx/:chainId/:emitter/:seq" element={<Tx />} />
           <Route path="/search-not-found" element={<SearchNotFound />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Tx/Information/Overview/index.tsx
+++ b/src/pages/Tx/Information/Overview/index.tsx
@@ -62,7 +62,6 @@ const Overview = ({ VAAData, txData }: Props) => {
   const { originTx, destinationTx } = globalTx || {};
   const isAttestation = txType[payloadType] === "Attestation";
   const isUnknownPayloadType = !txType[payloadType];
-  console.log({ isUnknownPayloadType: !txType[payloadType] });
 
   const {
     appIds,

--- a/src/pages/Txs/Information/index.tsx
+++ b/src/pages/Txs/Information/index.tsx
@@ -59,8 +59,8 @@ const Information = ({
   const navigate = useNavigateCustom();
 
   const onRowClick = (row: TransactionOutput) => {
-    const { id: txHash } = row || {};
-    txHash && navigate(`/tx/${txHash}`);
+    const { VAAId } = row || {};
+    VAAId && navigate(`/tx/${VAAId}`);
   };
 
   const goFirstPage = () => {

--- a/src/pages/Txs/index.tsx
+++ b/src/pages/Txs/index.tsx
@@ -18,7 +18,8 @@ import { useNavigateCustom } from "src/utils/hooks/useNavigateCustom";
 import "./styles.scss";
 
 export interface TransactionOutput {
-  id: string;
+  VAAId: string;
+  txHashId: string;
   txHash: React.ReactNode;
   from: React.ReactNode;
   to: React.ReactNode;
@@ -106,6 +107,7 @@ const Txs = () => {
         txs?.length > 0
           ? txs?.forEach(tx => {
               const {
+                id: VAAId,
                 txHash,
                 timestamp,
                 tokenAmount,
@@ -142,12 +144,13 @@ const Txs = () => {
               });
               const timestampDate = new Date(timestamp);
               const row = {
-                id: txHash,
+                VAAId: VAAId,
+                txHashId: txHash,
                 txHash: (
                   <div className="tx-hash">
                     {parseTxHash ? (
                       <>
-                        <NavLink to={`/tx/${txHash}`} onClick={stopPropagation}>
+                        <NavLink to={`/tx/${VAAId}`} onClick={stopPropagation}>
                           {shortAddress(parseTxHash).toUpperCase()}
                         </NavLink>
                         <CopyToClipboard toCopy={parseTxHash}>


### PR DESCRIPTION
# Description

- Add Search bar support to handle better Search by VAA Id
- Tx List items now search by VAA Id when goes to Tx Detail
- Handle `/txHash` and `/chainId/emitter/seq` URLs

### Examples:
- by `VAA Id`: /#/tx/2/0000000000000000000000003ee18b2214aff97000d974cf647e7c347e8fa585/119317
- by `Tx Hash`: /#/tx/40e460da4333bbb6ef4329cab799fd22ad7391e16dd0e1d5f294ac58baa13d92