### PR TITLE
Fix/wasm unsafe eval

### DIFF
--- a/.proxyrc.js
+++ b/.proxyrc.js
@@ -1,10 +1,14 @@
 module.exports = function (app) {
-  app.use(function (req, res, next) {
+  const isDev = process.env.NODE_ENV === "development";
+
+  const CSP = `default-src 'self' https:; object-src 'none'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' ${
+    isDev ? `'unsafe-inline' 'unsafe-eval'` : ""
+  } 'wasm-unsafe-eval'; connect-src * data:; frame-ancestors 'none';`;
+
+  app.use(function (_, res, next) {
     res.setHeader("strict-transport-security", "max-age=63072000; includeSubdomains; preload");
-    res.setHeader(
-      "content-security-policy",
-      "default-src 'self' https:; object-src 'none'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src * data:; frame-ancestors 'none';",
-    );
+    res.setHeader("content-security-policy", CSP);
+
     res.setHeader("x-content-type-options", "nosniff");
     res.setHeader("x-xss-protection", "1; mode=block");
     res.setHeader("referrer-policy", "same-origin");


### PR DESCRIPTION
# Description

- Add `wasm-unsafe-eval` in `content-security-policy` header
- Fix `.proxyrc.js` for dev mode.