### PR TITLE
build: reduce bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,20 @@
     "recoil": "0.7.6"
   },
   "alias": {
-    "src": "./src"
+    "src": "./src",
+    "@injectivelabs/sdk-ts": false,
+    "@injectivelabs/networks": false,
+    "@injectivelabs/utils": false,
+    "@terra-money/terra.js": false,
+    "@terra-money/terra.proto": false,
+    "@terra-money/legacy.proto": false,
+    "@xpla/xpla.js": false,
+    "aptos": false,
+    "@mysten/sui.js": false,
+    "near-api-js": false,
+    "@project-serum/anchor": false,
+    "lodash": false,
+    "elliptic": false
   },
   "lint-staged": {
     "*.{svg,ts,tsx,js,jsx,scss,css,md}": "prettier --write"


### PR DESCRIPTION
# Description

By removing some modules that we are not using right now (deps of `@certusone/wormhole-sdk`) from the `build` we reduced the bundle size by **64.78%**

Before:
<img width="378" alt="Pasted Graphic 1" src="https://github.com/XLabs/wormscan-ui/assets/25652943/349b8ee7-7bd6-4b9b-9142-59eb56366f6e">

After:
<img width="369" alt="Pasted Graphic" src="https://github.com/XLabs/wormscan-ui/assets/25652943/e9258824-f446-4b16-b289-0ac52d9dc6c4">

