### PR TITLE
feat(233,234): add new footer content and styling

### DIFF
--- a/src/components/atoms/Tag/index.tsx
+++ b/src/components/atoms/Tag/index.tsx
@@ -5,10 +5,12 @@ type Props = {
   children: React.ReactNode;
   color?: string;
   className?: string;
+  type?: "chip" | "default";
+  size?: "small" | "default";
 };
 
-const Tag = ({ children, color, className }: Props) => {
-  return <div className={`tag ${color} ${className}`}>{children}</div>;
+const Tag = ({ children, color, className, type = "default", size = "default" }: Props) => {
+  return <div className={`tag ${color} ${type} ${size} ${className}`}>{children}</div>;
 };
 
 export default Tag;

--- a/src/components/atoms/Tag/styles.scss
+++ b/src/components/atoms/Tag/styles.scss
@@ -7,12 +7,20 @@
   align-items: center;
   padding: 6px 14px;
   border-radius: 4px;
-
-  background-color: var(--color-white);
-  color: var(--color-black);
+  background-color: var(--color-white-10);
+  color: var(--color-white);
 
   &.blue {
     background-color: var(--color-information-30);
     color: var(--color-information-500);
+  }
+
+  &.chip {
+    border-radius: 16px;
+    padding: 4px 12px;
+  }
+
+  &.small {
+    font-size: 12px;
   }
 }

--- a/src/components/molecules/Footer/index.tsx
+++ b/src/components/molecules/Footer/index.tsx
@@ -1,18 +1,35 @@
 import { useTranslation } from "react-i18next";
-import { NavLink } from "src/components/atoms";
-import { DISCORD_URL, TWITTER_URL, WORMHOLE_DOCS_URL, XLABS_URL } from "src/consts";
+import { NavLink, Tag } from "src/components/atoms";
+import {
+  DISCORD_URL,
+  TWITTER_URL,
+  WORMHOLE_DOCS_URL,
+  XLABS_CAREERS_URL,
+  XLABS_URL,
+} from "src/consts";
 import DiscordIcon from "src/icons/DiscordIcon";
 import TwitterIcon from "src/icons/TwitterIcon";
 import WormholeBrand from "../WormholeBrand";
+import { PinTopIcon } from "@radix-ui/react-icons";
 import "./styles.scss";
 
 const Footer = () => {
   const { t } = useTranslation();
   const year = new Date().getFullYear();
 
+  const goTop = () => {
+    window.scrollTo(0, 0);
+  };
+
   return (
     <footer className="footer" data-testid="footer">
       <div className="footer-container">
+        <div className="footer-top-button-container">
+          <button type="button" className="footer-top-button" onClick={goTop}>
+            <PinTopIcon /> Back to Top
+          </button>
+        </div>
+
         <div className="footer-brand">
           <NavLink to="/" data-testid="footer-logo-link">
             <WormholeBrand size="regular" />
@@ -42,29 +59,51 @@ const Footer = () => {
         </div>
 
         <div className="footer-links" data-testid="footer-nav">
-          <div className="footer-links-item">
+          <div className="footer-links-item" data-link="home">
             <NavLink to="/">{t("home.footer.home")}</NavLink>
           </div>
 
-          <div className="footer-links-item">
+          <div className="footer-links-item" data-link="txs">
             <NavLink to="/txs">{t("home.footer.txs")}</NavLink>
           </div>
 
+          <div className="footer-links-item" data-link="contact">
+            <div className="footer-links-item">
+              <a href={DISCORD_URL} target="_blank" rel="noopener noreferrer">
+                {t("home.footer.contactUs")}
+              </a>
+            </div>
+          </div>
+
           <div className="footer-links-item">
+            <a href={XLABS_CAREERS_URL} target="_blank" rel="noopener noreferrer">
+              {t("home.footer.careers")}
+            </a>
+            <Tag type="chip" size="small">
+              {t("home.footer.hiring")}
+            </Tag>
+          </div>
+
+          <div className="footer-links-item" data-link="api">
             <a href={WORMHOLE_DOCS_URL} target="_blank" rel="noopener noreferrer">
               {t("home.footer.apiDoc")}
             </a>
           </div>
+
+          {/* ADD BUG BOUNTY LINK WHEN AVAILABLE */}
+          {/* <div className="footer-links-item" data-link="bounty">
+            <NavLink to="/">{t("home.footer.bugBounty")}</NavLink>
+          </div> */}
+        </div>
+
+        <div className="footer-built">
+          <a href={XLABS_URL} target="_blank" rel="noopener noreferrer">
+            Built by xLabs
+          </a>
         </div>
 
         <div className="footer-copy">
-          <div className="footer-copy-brand">&copy;{year} Wormholescan</div>
-          <div className="footer-copy-project">Wormhole Explorer</div>
-          <div className="footer-copy-powered">
-            <a href={XLABS_URL} target="_blank" rel="noopener noreferrer">
-              Built by xlabs
-            </a>
-          </div>
+          <div className="footer-copy-brand">&copy; {year} Wormholescan</div>
         </div>
       </div>
     </footer>

--- a/src/components/molecules/Footer/styles.scss
+++ b/src/components/molecules/Footer/styles.scss
@@ -4,71 +4,100 @@
   @include centered-row;
 
   min-height: 570px;
-  padding: 48px 16px 24px;
+  padding: 32px;
   background-color: rgba(1, 0, 20, 0.25);
   border-top: 1px solid var(--color-white-10);
 
   @include desktop {
-    padding: 36px 60px 24px;
+    padding: 60px 60px 40px;
     min-height: 168px;
   }
 
   &-container {
     display: grid;
     grid-template-areas:
+      "top-button"
       "brand"
       "links"
       "social"
+      "built"
       "copy";
-    column-gap: 32px;
-    row-gap: 72px;
+    grid-template-columns: 1fr;
+    column-gap: 16px;
+    row-gap: 56px;
     width: 100%;
     max-width: 425px;
     margin: 0 auto;
 
     @include desktop {
-      row-gap: 52px;
+      row-gap: 32px;
       grid-template-areas:
-        "brand links social"
-        "copy copy copy";
-      grid-template-columns: 1fr 1fr 1fr;
+        "brand links links top-button"
+        "brand links links social"
+        "built . . ."
+        "copy copy copy copy";
+      grid-template-columns: 1.1fr 1fr 1fr 1.1fr;
       max-width: unset;
       margin: auto;
+    }
+
+    @include bigDesktop {
+      grid-template-columns: 2fr 1fr 1fr 2fr;
+    }
+  }
+
+  &-top-button-container {
+    @include centered-row;
+
+    grid-area: top-button;
+    justify-content: end;
+
+    @include desktop {
+      align-items: start;
+    }
+  }
+
+  &-top-button {
+    @include text-p3;
+    @include centered-row;
+
+    color: var(--color-primary-50);
+    background-color: transparent;
+    border: none;
+    gap: 8px;
+    cursor: pointer;
+
+    &:hover {
+      color: var(--color-secondary-800);
     }
   }
 
   &-brand {
     @include centered-row;
 
-    justify-content: center;
     grid-area: brand;
-    padding: 0 32px;
-
-    a {
-      text-decoration: none;
-    }
+    height: 100%;
 
     @include desktop {
       width: 100%;
       margin: auto;
       padding: 0;
       justify-content: start;
+      align-items: start;
     }
   }
 
   &-social {
     @include centered-column;
 
-    align-items: center;
     grid-area: social;
     gap: 24px;
-    padding: 0 32px;
 
     @include desktop {
       @include centered-row;
 
       justify-content: flex-end;
-      gap: 40px;
+      gap: 24px;
       margin-bottom: 0;
       padding: 0;
     }
@@ -98,21 +127,49 @@
 
       @include desktop {
         flex: unset;
-        gap: 40px;
+        gap: 32px;
       }
     }
   }
 
   &-links {
     display: grid;
-    justify-content: center;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr;
     grid-area: links;
-    padding: 0 32px;
+
+    row-gap: 40px;
 
     @include desktop {
-      grid-template-columns: 1fr 1fr 1fr;
-      justify-content: center;
+      column-gap: 16px;
+
+      [data-link="home"] {
+        grid-area: home;
+      }
+
+      [data-link="careers"] {
+        grid-area: careers;
+      }
+
+      [data-link="api"] {
+        grid-area: api;
+      }
+
+      [data-link="txs"] {
+        grid-area: txs;
+      }
+
+      [data-link="contact"] {
+        grid-area: contact;
+      }
+
+      [data-link="bounty"] {
+        grid-area: bounty;
+      }
+
+      grid-template-columns: 1fr 1fr 0.5fr;
+      grid-template-areas:
+        "home careers api"
+        "txs contact bounty";
       padding: 0;
     }
 
@@ -120,10 +177,10 @@
       @include centered-row;
       width: 100%;
 
-      cursor: pointer;
+      display: flex;
+      gap: 8px;
       user-select: none;
       text-align: center;
-      justify-content: center;
 
       a {
         @include text-p3;
@@ -139,21 +196,38 @@
     }
   }
 
+  &-built {
+    @include text-p3;
+
+    grid-area: built;
+
+    & a {
+      text-decoration: none;
+      color: var(--color-secondary-800);
+
+      &:hover,
+      &:active {
+        text-decoration: underline;
+      }
+    }
+  }
+
   &-copy {
     @include centered-column;
     @include text-caption1;
 
     font-weight: 400;
     font-size: 14px;
-    text-align: center;
     grid-area: copy;
-    color: var(--color-white-30);
+    color: var(--color-white-40);
+    border-top: 1px solid var(--color-white-10);
+    padding-top: 32px;
 
     @include desktop {
       @include centered-row;
 
       justify-content: space-between;
-      font-size: 12px;
+      padding-top: 20px;
 
       & > * {
         flex: 1;
@@ -163,50 +237,10 @@
         }
       }
 
-      &-powered {
-        text-align: left;
-      }
-
       &-brand {
-        text-align: right;
-      }
-    }
+        @include text-p2;
 
-    &-brand {
-      order: 1;
-
-      @include desktop {
-        order: 3;
-      }
-    }
-
-    &-project {
-      order: 2;
-    }
-
-    &-powered {
-      order: 3;
-      margin-top: 80px;
-      color: var(--color-white-40);
-      font-size: 12px;
-
-      & a {
-        text-decoration: none;
-        color: var(--color-white-40);
-
-        &:hover,
-        &:active {
-          color: var(--color-information-100);
-        }
-      }
-
-      @include desktop {
-        order: 1;
-        margin: 0;
-
-        & a {
-          color: var(--color-white-30);
-        }
+        text-align: center;
       }
     }
   }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -128,3 +128,4 @@ export const TWITTER_URL = "https://twitter.com/wormholecrypto";
 export const DISCORD_URL = "https://discord.com/invite/wormholecrypto";
 export const XLABS_URL = "https://www.xlabs.xyz";
 export const WORMHOLE_DOCS_URL = "https://docs.wormholescan.io";
+export const XLABS_CAREERS_URL = "https://boards.greenhouse.io/xlabs";

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -20,6 +20,10 @@ export default {
           txs: "Txs",
           joinUs: "Join us",
           apiDoc: "API Doc",
+          bugBounty: "Bug Bounty",
+          careers: "Careers",
+          contactUs: "Contact us",
+          hiring: "We're hiring!",
         },
         hero: {
           text: "Cross-chain Explorer",


### PR DESCRIPTION
# Description

Fixes 233, 234

- Add new content for the `Footer` component on desktop and mobile.

Desktop:
![image](https://github.com/XLabs/wormscan-ui/assets/25652943/3a41190d-1fcd-462c-bc80-e05581b9078a)

Mobile:
![image](https://github.com/XLabs/wormscan-ui/assets/25652943/8c82e111-754b-4760-b284-0ab138367f11)
