### PR TITLE
feat: add 5 visible page numbers

### DIFF
--- a/src/components/atoms/Pagination/index.tsx
+++ b/src/components/atoms/Pagination/index.tsx
@@ -6,6 +6,7 @@ type Props = {
   currentPage?: number;
   goNextPage?: () => void;
   goLastPage?: () => void;
+  goPage?: (pageNumber: number) => void;
   totalPages?: number | undefined;
   className?: string;
   disabled?: boolean;
@@ -18,7 +19,8 @@ const Pagination = ({
   currentPage = 1,
   goNextPage,
   goLastPage,
-  totalPages = undefined,
+  goPage,
+  totalPages = Infinity,
   className,
   disabled = false,
   disableNextButton = false,
@@ -38,7 +40,11 @@ const Pagination = ({
         &lt;
       </button>
 
-      <span className="pagination-current">{currentPage}</span>
+      {goPage ? (
+        <PageNumbers currentPage={currentPage} goPage={goPage} />
+      ) : (
+        <span className={`pagination number current`}>{currentPage}</span>
+      )}
 
       <button onClick={goNextPage} disabled={disabled || disableNextButton || isLastPage}>
         &gt;
@@ -54,6 +60,33 @@ const Pagination = ({
         </button>
       )}
     </div>
+  );
+};
+
+const PageNumbers = ({
+  currentPage,
+  goPage,
+}: {
+  currentPage?: number;
+  goPage?: (pageNumber: number) => void;
+}) => {
+  const TOTAL_PREV_VISIBLE_PAGES = 2;
+  const isPrevOffset = currentPage - TOTAL_PREV_VISIBLE_PAGES >= TOTAL_PREV_VISIBLE_PAGES;
+  const firstPrevOffsetPageNumber = currentPage - TOTAL_PREV_VISIBLE_PAGES;
+  const pages = [...Array(5)].map((_, i) => (isPrevOffset ? firstPrevOffsetPageNumber + i : i + 1));
+
+  return (
+    <>
+      {pages.map((page, index) => (
+        <button
+          key={index}
+          className={`pagination number ${page === currentPage ? "current" : "page"}`}
+          onClick={() => goPage && goPage(page)}
+        >
+          {page}
+        </button>
+      ))}
+    </>
   );
 };
 

--- a/src/components/atoms/Pagination/styles.scss
+++ b/src/components/atoms/Pagination/styles.scss
@@ -1,6 +1,7 @@
 @import "src/styles/globals.scss";
 
 .pagination {
+  display: flex;
   color: var(--color-secondary-800);
   min-height: 38px;
   font-size: 15px;
@@ -52,8 +53,19 @@
     cursor: not-allowed;
   }
 
-  &-current {
-    color: var(--color-white);
+  &.number {
+    &.page {
+      color: var(--color-white-20);
+    }
+
+    &.current {
+      color: var(--color-white);
+    }
+
+    &:active {
+      background-color: var(--color-secondary-800);
+      color: var(--color-white);
+    }
   }
 
   &-last-page {

--- a/src/pages/Txs/Information/index.tsx
+++ b/src/pages/Txs/Information/index.tsx
@@ -47,6 +47,7 @@ interface Props {
   onChangePagination: (pageNumber: number) => void;
   isPaginationLoading: boolean;
   setIsPaginationLoading: Dispatch<SetStateAction<boolean>>;
+  isTxsFiltered: boolean;
 }
 
 const Information = ({
@@ -55,6 +56,7 @@ const Information = ({
   onChangePagination,
   isPaginationLoading,
   setIsPaginationLoading,
+  isTxsFiltered = false,
 }: Props) => {
   const navigate = useNavigateCustom();
 
@@ -80,6 +82,11 @@ const Information = ({
     onChangePagination(nextPage);
   };
 
+  const goPage = (currentPage: number) => {
+    setIsPaginationLoading(true);
+    onChangePagination(currentPage);
+  };
+
   const PaginationComponent = ({ className }: { className?: string }) => {
     return (
       <Pagination
@@ -88,6 +95,7 @@ const Information = ({
         goPrevPage={() => goPrevPage(currentPage)}
         goNextPage={() => goNextPage(currentPage)}
         // goLastPage={() => goLastPage()}
+        goPage={isTxsFiltered ? null : goPage}
         disabled={isPaginationLoading}
         disableNextButton={parsedTxsData.length <= 0 || parsedTxsData.length < PAGE_SIZE}
         className={className}
@@ -112,13 +120,15 @@ const Information = ({
           {isPaginationLoading ? (
             <Loader />
           ) : (
-            <Table
-              columns={columns}
-              data={parsedTxsData}
-              className="txs"
-              emptyMessage="No txs found."
-              onRowClick={onRowClick}
-            />
+            <div className="table-container">
+              <Table
+                columns={columns}
+                data={parsedTxsData}
+                className="txs"
+                emptyMessage="No txs found."
+                onRowClick={onRowClick}
+              />
+            </div>
           )}
 
           <div className="txs-pagination">

--- a/src/pages/Txs/Information/styles.scss
+++ b/src/pages/Txs/Information/styles.scss
@@ -5,15 +5,19 @@
 
   margin-bottom: 32px;
   padding: 0 !important;
-  overflow-x: auto;
-  overflow-y: visible;
-  height: 100%;
+  // overflow-x: auto;
+  // overflow-y: visible;
+  // height: 100%;
 
   &-loader {
     @include centered-row;
     justify-content: center;
     height: 100%;
     min-height: 220px;
+  }
+
+  & .table-container {
+    overflow-x: auto;
   }
 
   &-table-results {
@@ -57,6 +61,7 @@
 
     &-pagination {
       @include centered-row;
+      justify-content: center;
 
       padding: 24px 16px;
 
@@ -108,13 +113,12 @@
 
   .txs-pagination {
     display: flex;
-    justify-content: start;
-    margin: 75px 0 48px;
-    padding: 0 16px;
+    justify-content: center;
+    padding: 48px 16px;
 
     @include desktop {
       justify-content: end;
-      padding: 0 32px;
+      padding: 32px;
     }
   }
 }

--- a/src/pages/Txs/Information/styles.scss
+++ b/src/pages/Txs/Information/styles.scss
@@ -5,9 +5,6 @@
 
   margin-bottom: 32px;
   padding: 0 !important;
-  // overflow-x: auto;
-  // overflow-y: visible;
-  // height: 100%;
 
   &-loader {
     @include centered-row;

--- a/src/pages/Txs/index.tsx
+++ b/src/pages/Txs/index.tsx
@@ -15,8 +15,8 @@ import { Information } from "./Information";
 import { Top } from "./Top";
 import { TxStatus } from "../../types";
 import { useNavigateCustom } from "src/utils/hooks/useNavigateCustom";
-import "./styles.scss";
 import { useEnvironment } from "src/context/EnvironmentContext";
+import "./styles.scss";
 
 export interface TransactionOutput {
   VAAId: string;
@@ -41,6 +41,7 @@ const Txs = () => {
   const address = searchParams.get("address");
   const page = Number(searchParams.get("page"));
   const currentPage = page >= 1 ? page : 1;
+  const isTxsFiltered = address ? true : false;
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isPaginationLoading, setIsPaginationLoading] = useState<boolean>(false);
   const [addressChainId, setAddressChainId] = useState<ChainId | undefined>(undefined);
@@ -259,6 +260,7 @@ const Txs = () => {
               onChangePagination={onChangePagination}
               isPaginationLoading={isPaginationLoading}
               setIsPaginationLoading={setIsPaginationLoading}
+              isTxsFiltered={isTxsFiltered}
             />
           </>
         )}


### PR DESCRIPTION
# Description

Fix 239

- Add 5 page numbers buttons into the pagination component.

Desktop:

![image](https://github.com/XLabs/wormscan-ui/assets/25652943/f593a5e6-b97e-428c-89fb-0e7b7c3188ab)

Mobile:

![image](https://github.com/XLabs/wormscan-ui/assets/25652943/56ab3a35-72aa-4c47-8c2d-6bfac60ce084)


### Note

This is how is displayed when the `txs` are not filtered by any
