### PR TITLE
Better txHash search support

### DIFF
--- a/src/components/molecules/Header/Search/index.tsx
+++ b/src/components/molecules/Header/Search/index.tsx
@@ -59,7 +59,7 @@ const Search = () => {
       }),
     {
       onSuccess: vaa => {
-        const { txHash } = vaa || {};
+        const { txHash } = vaa?.[0] || {};
         if (txHash) {
           queryClient.setQueryData(["getVAAbyTxHash", txHash], vaa);
           navigate(`/tx/${txHash}`);

--- a/src/pages/Txs/Information/index.tsx
+++ b/src/pages/Txs/Information/index.tsx
@@ -68,8 +68,8 @@ const Information = ({
   const currentUrlPage = +new URLSearchParams(location.search).get("page") || 1;
 
   const onRowClick = (row: TransactionOutput) => {
-    const { VAAId } = row || {};
-    VAAId && navigate(`/tx/${VAAId}`);
+    const { txHashId } = row || {};
+    txHashId && navigate(`/tx/${txHashId}`);
   };
 
   const goFirstPage = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3534,12 +3534,12 @@ __metadata:
 
 "@xlabs-libs/wormscan-sdk@https://github.com/xlabs/wormscan-sdk#lib":
   version: 0.0.19
-  resolution: "@xlabs-libs/wormscan-sdk@https://github.com/xlabs/wormscan-sdk.git#commit=511c91e3ef4a1a6d1d6e42b2e1cd5e594af99f88"
+  resolution: "@xlabs-libs/wormscan-sdk@https://github.com/xlabs/wormscan-sdk.git#commit=23c31bcd30145c46d7d07187c018e3a807590dd2"
   dependencies:
     axios: ^1.2.5
   peerDependencies:
     axios: ^1.2.5
-  checksum: 513ca61671baa84feae7865703095b79bbe9c8c9e54c41dc5aefdd73aa89f7c7e0683f62f5f3926f10105634dca38d0996acc85ede8ac33aae1a33d92f18bc15
+  checksum: 6df8bced1d98f23fc5b2f48eff27cc38bdfdc9a18797145659a34cb313bd89b267c6dd8ab38ed4fff8b3246e96ee2455a4a4052affa1feafeb73ee6d5577bf07
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

One transaction hash can have multiple VAAs associated with it. We were not handling that possibility. This PR fixes that.

### Changes Done

- Prioritize txHash search instead of VAA-ID search: On the transactions list, when a user presses on a transaction, it goes to the transaction hash detail instead of going to the VAA-ID detail.
- If the result of a txHash search has multiple VAAs, show them all, one below each other. _(don't worry about it looking kinda overkill with the info, the design for this will change soon)_

### Screenshot

**BEFORE**
![before](https://github.com/XLabs/wormscan-ui/assets/41705567/05334f7d-5993-4d29-b8a3-897632e827e7)

**AFTER**
![after](https://github.com/XLabs/wormscan-ui/assets/41705567/06dfefa5-b2de-4222-952d-1595dabe3f11)
