### PR TITLE
Feat: Targets always at right on cross-chain chart

### DIFF
--- a/src/components/atoms/Pagination/index.tsx
+++ b/src/components/atoms/Pagination/index.tsx
@@ -11,6 +11,7 @@ type Props = {
   className?: string;
   disabled?: boolean;
   disableNextButton?: boolean;
+  style?: object;
 };
 
 const Pagination = ({
@@ -24,12 +25,13 @@ const Pagination = ({
   className = "",
   disabled = false,
   disableNextButton = false,
+  style = {},
 }: Props) => {
   const isFirstPage = currentPage === 1;
   const isLastPage = currentPage === totalPages;
 
   return (
-    <div className={`pagination ${className}`}>
+    <div className={`pagination ${className}`} style={style}>
       {goFirstPage && (
         <button onClick={goFirstPage} disabled={disabled || isFirstPage}>
           &lt;&lt;

--- a/src/components/molecules/CrossChainChart/Chart.tsx
+++ b/src/components/molecules/CrossChainChart/Chart.tsx
@@ -77,8 +77,6 @@ export const Chart = ({ data, selectedType, selectedDestination }: Props) => {
           return !!item.selected;
         });
 
-      console.log({ destinyChainsHeight, originChainsHeight, selected });
-
       if (selectedDestination === "sources") {
         // start point: the Y position from where to start the graphs (count previous items heights)
         const START_POINT = originChainsHeight.slice(0, selectedIdx).reduce(

--- a/src/components/molecules/CrossChainChart/StickyInfo.tsx
+++ b/src/components/molecules/CrossChainChart/StickyInfo.tsx
@@ -9,12 +9,19 @@ import { Info } from "./Chart";
 
 type Props = {
   chainName: string;
+  destinations: any[];
+  selectedDestination: "sources" | "destinations";
   selectedInfo: Info;
   selectedType: CrossChainBy;
-  destinations: any[];
 };
 
-export const StickyInfo = ({ chainName, selectedInfo, selectedType, destinations }: Props) => {
+export const StickyInfo = ({
+  chainName,
+  destinations,
+  selectedDestination,
+  selectedInfo,
+  selectedType,
+}: Props) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const stickyRef = useRef<HTMLDivElement>(null);
@@ -72,7 +79,9 @@ export const StickyInfo = ({ chainName, selectedInfo, selectedType, destinations
               <div className="cross-chain-sticky-line-draw" />
             </div>
 
-            <div className="cross-chain-sticky-subtitle">Source</div>
+            <div className="cross-chain-sticky-subtitle">
+              {selectedDestination === "sources" ? "Source" : "Target"}
+            </div>
             <div className="cross-chain-sticky-info">
               <span className="cross-chain-sticky-info-source">{chainName}</span>
               <span className="cross-chain-sticky-info-value">
@@ -88,7 +97,9 @@ export const StickyInfo = ({ chainName, selectedInfo, selectedType, destinations
         <div className="cross-chain-sticky-destinations" style={{ opacity: isOpen ? 1 : 0 }}>
           <div className="cross-chain-sticky-separator" />
 
-          <div className="cross-chain-sticky-subtitle">Destination</div>
+          <div className="cross-chain-sticky-subtitle">
+            {selectedDestination === "sources" ? "Destinations" : "Sources"}
+          </div>
 
           {destinations.map(destination => (
             <div key={destination.chain} className="cross-chain-sticky-info spaced">

--- a/src/components/molecules/CrossChainChart/index.tsx
+++ b/src/components/molecules/CrossChainChart/index.tsx
@@ -79,15 +79,15 @@ const CrossChainChart = () => {
             aria-label="Select graphic type"
             onClick={() => setSelectedDestination(isSources ? "destinations" : "sources")}
           >
-            <span>{isSources ? "Source" : "Target"}</span>
+            <span>Source</span>
             <div className="cross-chain-destination-arrow">
-              {isSources ? (
-                <ArrowRightIcon width={20} height={20} />
-              ) : (
-                <ArrowLeftIcon width={20} height={20} />
-              )}
+              <ArrowLeftIcon
+                width={20}
+                height={20}
+                className={`cross-chain-destination-arrow-icon ${isSources ? "right" : "left"}`}
+              />
             </div>
-            <span>{isSources ? "Target" : "Source"}</span>
+            <span>Target</span>
           </div>
         </div>
 
@@ -123,11 +123,12 @@ const CrossChainChart = () => {
       )}
 
       <div className="cross-chain-message">
-        <div>{t("home.crossChain.portalActivity")}</div>
-        {selectedDestination === "sources" ? (
-          <div>{t("home.crossChain.bottomMessageSources")}</div>
-        ) : (
+        {selectedDestination === "destinations" && (
           <div>{t("home.crossChain.bottomMessageDestinations")}</div>
+        )}
+        <div>Wormhole Activity</div>
+        {selectedDestination === "sources" && (
+          <div>{t("home.crossChain.bottomMessageSources")}</div>
         )}
       </div>
     </div>

--- a/src/components/molecules/CrossChainChart/styles.scss
+++ b/src/components/molecules/CrossChainChart/styles.scss
@@ -100,6 +100,17 @@
       width: 24px;
       background-color: var(--color-secondary-800);
       border-radius: 8px;
+
+      &-icon {
+        &.right {
+          transform: rotate(180deg);
+        }
+        &.left {
+          transform: rotate(0deg);
+        }
+
+        transition: all 0.4s ease-out;
+      }
     }
   }
 
@@ -167,9 +178,21 @@
         display: grid;
         grid-auto-flow: column;
         align-items: center;
-        border-left: 16px solid var(--color-information-60);
         position: relative;
         grid-template-columns: 70px 60px;
+
+        &.left {
+          border-left: 16px solid var(--color-information-60);
+          @include desktop {
+            border-left: 0;
+          }
+        }
+        &.right {
+          border-right: 16px solid var(--color-information-60);
+          @include desktop {
+            border-right: 0;
+          }
+        }
 
         @media only screen and (min-width: 425px) {
           grid-template-columns: 85px 30px 40px;
@@ -184,7 +207,6 @@
         @include desktop {
           grid-template-columns: 1.5fr 5fr 1fr;
           background: withOpacity(var(--color-primary-100), 0.2);
-          border-left: 0;
         }
         @include bigDesktop {
           grid-template-columns: 1.2fr 3.6fr 2fr 0.2fr 4fr;
@@ -258,7 +280,7 @@
           }
         }
 
-        &.left {
+        &.selectable {
           cursor: pointer;
 
           .volume-info {
@@ -293,22 +315,43 @@
           .chain-name {
             opacity: 1;
           }
-          &.left {
-            border-left: 16px solid var(--color-information-100);
+          &.selectable {
+            &.left {
+              border-left: 16px solid var(--color-information-100);
+              background: linear-gradient(
+                90deg,
+                rgba(15, 12, 72, 0.71) 9.64%,
+                rgba(15, 12, 72, 0) 95.18%
+              );
+              @include desktop {
+                border-left: 0px;
+                background: withOpacity(var(--color-primary-300), 0.5);
+              }
+            }
+            &.right {
+              border-right: 16px solid var(--color-information-100);
 
-            // TODO: use color variable here
-            background: linear-gradient(
-              90deg,
-              rgba(15, 12, 72, 0.71) 9.64%,
-              rgba(15, 12, 72, 0) 95.18%
-            );
-            @include desktop {
-              border-left: 0px;
-              background: withOpacity(var(--color-primary-300), 0.5);
+              background: linear-gradient(
+                90deg,
+                rgba(15, 12, 72, 0) 9.64%,
+                rgba(15, 12, 72, 0.71) 95.18%
+              );
+              @include desktop {
+                border-right: 0px;
+                background: withOpacity(var(--color-primary-300), 0.5);
+              }
             }
           }
-          @include desktop {
-            border-right: 4px solid var(--color-information-100);
+
+          &.left {
+            @include desktop {
+              border-right: 4px solid var(--color-information-100);
+            }
+          }
+          &.right {
+            @include desktop {
+              border-left: 4px solid var(--color-information-100);
+            }
           }
         }
 
@@ -331,7 +374,7 @@
           }
         }
 
-        &.right {
+        &.nonSelectable {
           .percentage {
             display: block;
           }
@@ -356,19 +399,43 @@
           }
 
           justify-content: end;
-          border-left: 0px;
-          border-right: 8px solid var(--color-information-100);
-          // TODO: use color variable here
-          background: linear-gradient(
-            90deg,
-            rgba(15, 12, 72, 0) 9.64%,
-            rgba(15, 12, 72, 0.71) 95.18%
-          );
+
+          &.right {
+            border-left: 0px;
+            border-right: 8px solid var(--color-information-100);
+          }
+          &.left {
+            border-right: 0px;
+            border-left: 8px solid var(--color-information-100);
+          }
+
+          &.right {
+            background: linear-gradient(
+              90deg,
+              rgba(15, 12, 72, 0) 9.64%,
+              rgba(15, 12, 72, 0.71) 95.18%
+            );
+            @include desktop {
+              background: withOpacity(var(--color-primary-100), 0.2);
+              border-right: 0px;
+              border-left: 4px solid var(--color-information-100);
+            }
+          }
+          &.left {
+            background: linear-gradient(
+              90deg,
+              rgba(15, 12, 72, 0.71) 9.64%,
+              rgba(15, 12, 72, 0) 95.18%
+            );
+            @include desktop {
+              background: withOpacity(var(--color-primary-100), 0.2);
+              border-right: 4px solid var(--color-information-100);
+              border-left: 0px;
+            }
+          }
+
           @include desktop {
             align-items: center;
-            border-left: 4px solid var(--color-information-100);
-            border-right: 0px;
-            background: withOpacity(var(--color-primary-100), 0.2);
           }
         }
       }

--- a/src/components/molecules/ScoreCard/index.tsx
+++ b/src/components/molecules/ScoreCard/index.tsx
@@ -40,6 +40,35 @@ const ScoreCard = () => {
             <div className="home-statistics-data-container">
               <div className="home-statistics-data-container-item end">
                 <div className="home-statistics-data-container-item-title">
+                  {t("home.statistics.allTxn")}
+                </div>
+                <div className="home-statistics-data-container-item-value">
+                  {total_tx_count ? numberToSuffix(Number(total_tx_count)) : "-"}
+                </div>
+              </div>
+
+              <div className="home-statistics-data-container-item end">
+                <div className="home-statistics-data-container-item-title">
+                  {t("home.statistics.dayTxn")}
+                </div>
+                <div className="home-statistics-data-container-item-value">
+                  {tx_count24h ? formatNumber(Number(tx_count24h), 0) : "-"}
+                </div>
+              </div>
+
+              <div className="home-statistics-data-container-item end">
+                <div className="home-statistics-data-container-item-title">
+                  {t("home.statistics.dayMessage")}
+                </div>
+                <div className="home-statistics-data-container-item-value">
+                  {messages24h ? formatNumber(Number(messages24h), 0) : "-"}
+                </div>
+              </div>
+
+              <hr />
+
+              <div className="home-statistics-data-container-item start">
+                <div className="home-statistics-data-container-item-title">
                   {t("home.statistics.tvl")}
                 </div>
                 <div className="home-statistics-data-container-item-value">
@@ -51,7 +80,7 @@ const ScoreCard = () => {
                 </div>
               </div>
 
-              <div className="home-statistics-data-container-item end">
+              <div className="home-statistics-data-container-item start">
                 <div className="home-statistics-data-container-item-title">
                   {t("home.statistics.allVolume")}
                 </div>
@@ -64,17 +93,6 @@ const ScoreCard = () => {
                 </div>
               </div>
 
-              <div className="home-statistics-data-container-item end">
-                <div className="home-statistics-data-container-item-title">
-                  {t("home.statistics.allTxn")}
-                </div>
-                <div className="home-statistics-data-container-item-value">
-                  {total_tx_count ? numberToSuffix(Number(total_tx_count)) : "-"}
-                </div>
-              </div>
-
-              <hr />
-
               <div className="home-statistics-data-container-item start">
                 <div className="home-statistics-data-container-item-title">
                   {t("home.statistics.messageVolume")}
@@ -85,24 +103,6 @@ const ScoreCard = () => {
                   ) : (
                     "-"
                   )}
-                </div>
-              </div>
-
-              <div className="home-statistics-data-container-item start">
-                <div className="home-statistics-data-container-item-title">
-                  {t("home.statistics.dayTxn")}
-                </div>
-                <div className="home-statistics-data-container-item-value">
-                  {tx_count24h ? formatNumber(Number(tx_count24h), 0) : "-"}
-                </div>
-              </div>
-
-              <div className="home-statistics-data-container-item start">
-                <div className="home-statistics-data-container-item-title">
-                  {t("home.statistics.dayMessage")}
-                </div>
-                <div className="home-statistics-data-container-item-value">
-                  {messages24h ? formatNumber(Number(messages24h), 0) : "-"}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Changes Done

- Sankey chart modification so source information is always on the left and target information is always on the right. When it's showing targets information it makes the right side clickable and the pagination moves to the right.
- Changed order for wormhole stats on main page

### Screenshots

**DESKTOP**
![desktop](https://github.com/XLabs/wormscan-ui/assets/41705567/8d89bfa6-e018-4af0-be09-8f9dd3cd0bf9)


**MOBILE**
![mobile](https://github.com/XLabs/wormscan-ui/assets/41705567/80c05a3b-95f8-4924-a51d-b7fb4303192d)


**WH STATS TESTNET**
![testnet wh stats](https://github.com/XLabs/wormscan-ui/assets/41705567/079638bc-7f3e-4bb0-85c2-7c5ca9fcf85a)
