### PR TITLE
Add search param for tx detail selection

### DIFF
--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { ChainId } from "@certusone/wormhole-sdk";
+import { useSearchParams } from "react-router-dom";
 
 import { useEnvironment } from "src/context/EnvironmentContext";
 import { txType } from "src/consts";
@@ -34,7 +35,17 @@ interface Props {
 const UNKNOWN_APP_ID = "UNKNOWN";
 
 const Information = ({ extraRawInfo, VAAData, txData }: Props) => {
-  const [showOverview, setShowOverview] = useState(true);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [showOverview, setShowOverviewState] = useState(searchParams.get("view") !== "rawdata");
+  const setShowOverview = (show: boolean) => {
+    setShowOverviewState(show);
+    setSearchParams(prev => {
+      prev.set("view", show ? "overview" : "rawdata");
+      return prev;
+    });
+  };
+
   const [showOverviewDetail, setShowOverviewDetail] = useLocalStorage<boolean>(
     "showOverviewDetail",
     false,


### PR DESCRIPTION
### Description

- This PR adds a search parameter to the tx detail page so users can share directly the "raw data" url for a transaction

---

![1VHIodw](https://github.com/XLabs/wormscan-ui/assets/41705567/c812482f-84c5-4775-bd37-b76901a4d271)
