### PR TITLE
Fix when symbol not found, show N/A

### DIFF
--- a/src/components/molecules/Header/index.tsx
+++ b/src/components/molecules/Header/index.tsx
@@ -191,7 +191,7 @@ const Header = () => {
         </div>
       </div>
 
-      <label
+      <div
         className={`header-menu-mobile-mask header-menu-mobile-mask--${
           expandMobileMenu ? "open" : "close"
         }`}

--- a/src/pages/Tx/Information/Details/index.tsx
+++ b/src/pages/Tx/Information/Details/index.tsx
@@ -140,15 +140,20 @@ const Details = ({
           {tokenAmount ? (
             <>
               {amountSent}{" "}
-              {symbol &&
-                (tokenLink ? (
-                  <a href={tokenLink} target="_blank" rel="noopener noreferrer">
-                    {symbol}
-                  </a>
-                ) : (
-                  <span>{symbol}</span>
-                ))}
-              {amountSentUSD && `(${amountSentUSD} USD)`}
+              {symbol ? (
+                <>
+                  {tokenLink ? (
+                    <a href={tokenLink} target="_blank" rel="noopener noreferrer">
+                      {symbol}
+                    </a>
+                  ) : (
+                    <span>{symbol}</span>
+                  )}
+                  {amountSentUSD && `(${amountSentUSD} USD)`}
+                </>
+              ) : (
+                "N/A"
+              )}
             </>
           ) : (
             "N/A"
@@ -286,15 +291,20 @@ const Details = ({
           ) : tokenAmount ? (
             <>
               {amountSent}{" "}
-              {symbol &&
-                (tokenLink ? (
-                  <a href={tokenLink} target="_blank" rel="noopener noreferrer">
-                    {symbol}
-                  </a>
-                ) : (
-                  <span>{symbol}</span>
-                ))}
-              {amountSentUSD && `(${amountSentUSD} USD)`}
+              {symbol ? (
+                <>
+                  {tokenLink ? (
+                    <a href={tokenLink} target="_blank" rel="noopener noreferrer">
+                      {symbol}
+                    </a>
+                  ) : (
+                    <span>{symbol}</span>
+                  )}
+                  {amountSentUSD && `(${amountSentUSD} USD)`}
+                </>
+              ) : (
+                "N/A"
+              )}
             </>
           ) : (
             "N/A"

--- a/src/pages/Tx/Information/Overview/index.tsx
+++ b/src/pages/Tx/Information/Overview/index.tsx
@@ -90,15 +90,20 @@ const Overview = ({
               {tokenAmount ? (
                 <>
                   {amountSent}{" "}
-                  {symbol &&
-                    (tokenLink ? (
-                      <a href={tokenLink} target="_blank" rel="noopener noreferrer">
-                        {symbol}
-                      </a>
-                    ) : (
-                      <span>{symbol}</span>
-                    ))}
-                  {amountSentUSD && `(${amountSentUSD} USD)`}
+                  {symbol ? (
+                    <>
+                      {tokenLink ? (
+                        <a href={tokenLink} target="_blank" rel="noopener noreferrer">
+                          {symbol}
+                        </a>
+                      ) : (
+                        <span>{symbol}</span>
+                      )}
+                      {amountSentUSD && `(${amountSentUSD} USD)`}
+                    </>
+                  ) : (
+                    "N/A"
+                  )}
                 </>
               ) : (
                 "N/A"
@@ -306,15 +311,20 @@ const Overview = ({
                 ) : tokenAmount ? (
                   <>
                     {amountSent}{" "}
-                    {symbol &&
-                      (tokenLink ? (
-                        <a href={tokenLink} target="_blank" rel="noopener noreferrer">
-                          {symbol}
-                        </a>
-                      ) : (
-                        <span>{symbol}</span>
-                      ))}
-                    {amountSentUSD && `(${amountSentUSD} USD)`}
+                    {symbol ? (
+                      <>
+                        {tokenLink ? (
+                          <a href={tokenLink} target="_blank" rel="noopener noreferrer">
+                            {symbol}
+                          </a>
+                        ) : (
+                          <span>{symbol}</span>
+                        )}
+                        {amountSentUSD && `(${amountSentUSD} USD)`}
+                      </>
+                    ) : (
+                      "N/A"
+                    )}
                   </>
                 ) : (
                   "N/A"

--- a/src/pages/Txs/index.tsx
+++ b/src/pages/Txs/index.tsx
@@ -251,7 +251,9 @@ const Txs = () => {
                     <StatusBadge status={status as TxStatus} />
                   </div>
                 ),
-                amount: tokenAmount ? formatCurrency(Number(tokenAmount)) + " " + symbol : "-",
+                amount: tokenAmount
+                  ? formatCurrency(Number(tokenAmount)) + " " + (symbol ? symbol : "N/A")
+                  : "-",
                 time: (timestampDate && timeAgo(timestampDate)) || "-",
               };
 


### PR DESCRIPTION
## Description #351 

- Show N/A when the symbol is not found.

### Before
![before](https://github.com/XLabs/wormscan-ui/assets/88043910/1bc1f4cc-8e08-44fa-a38e-35edd068b29c)

### After
![after](https://github.com/XLabs/wormscan-ui/assets/88043910/421f8675-3084-4f58-86e5-ba0be80f4eea)
