### PR TITLE
RPCs info support for wh-connect and fixes

### DIFF
--- a/src/pages/Tx/Information/RawData/index.tsx
+++ b/src/pages/Tx/Information/RawData/index.tsx
@@ -68,7 +68,7 @@ type Props = {
 const RawData = ({ extraRawInfo, VAAData, txData, lifecycleRecord }: Props) => {
   const { payload, decodedVaa, ...rest } = VAAData || {};
   const rawData = { ...rest };
-  const signedVAA = Object.values(decodedVaa).length > 0 ? decodedVaa : null;
+  const signedVAA = decodedVaa ? (Object.values(decodedVaa).length > 0 ? decodedVaa : null) : null;
 
   const CODE_BLOCKS = [
     {
@@ -149,11 +149,6 @@ const RawData = ({ extraRawInfo, VAAData, txData, lifecycleRecord }: Props) => {
                     "Source Delivery Provider": Buffer.from(
                       deliveryInstruction.sourceDeliveryProvider,
                     ).toString("hex"),
-                    "Additional Vaa Keys": deliveryInstruction.vaaKeys.map(vaaKey => ({
-                      Chain: vaaKey.chainId,
-                      Emitter: Buffer.from(vaaKey.emitterAddress).toString("hex"),
-                      Sequence: vaaKey.sequence,
-                    })),
                     "Encoded Execution Info:": decodeExecution
                       ? {
                           gasLimit: decodeExecution.gasLimit,

--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -58,7 +58,7 @@ const Information = ({ extraRawInfo, VAAData, txData, blockData }: Props) => {
   const { decodedVaa, vaa } = VAAData || {};
   const { guardianSignatures } = decodedVaa || {};
   const guardianSignaturesCount = guardianSignatures?.length || 0;
-  const hasVAA = !vaa;
+  const hasVAA = !!vaa;
 
   const { currentBlock, lastFinalizedBlock } = blockData || {};
 
@@ -148,7 +148,9 @@ const Information = ({ extraRawInfo, VAAData, txData, blockData }: Props) => {
 
   const amountSent = formatCurrency(Number(tokenAmount));
   const amountSentUSD = +usdAmount ? formatCurrency(+usdAmount) : "";
-  const redeemedAmount = formatCurrency(formatUnits(+amount - +fee));
+  const redeemedAmount = hasVAA
+    ? formatCurrency(formatUnits(+amount - +fee))
+    : formatCurrency(+amount - +fee);
 
   const tokenLink = getExplorerLink({
     network: currentNetwork,
@@ -266,13 +268,14 @@ const Information = ({ extraRawInfo, VAAData, txData, blockData }: Props) => {
   };
 
   const AlertsContent = () => {
-    if (!hasVAA && !isUnknownPayloadType) return null;
+    if (hasVAA && !isUnknownPayloadType) return null;
     return (
       <div className="tx-information-alerts">
         <Alert type="info" className="tx-information-alerts-unknown-payload-type">
-          {hasVAA ? (
+          {!hasVAA ? (
             <>
               <p>The VAA for this transaction has not been issued yet.</p>
+              <p>This information can be incomplete or have wrong values.</p>
               <p>
                 Waiting for finality on {getChainName({ chainId: fromChain })} which may take up to
                 15 minutes.

--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -49,7 +49,7 @@ const Tx = () => {
     () =>
       getClient().guardianNetwork.getVAAbyTxHash({
         query: {
-          txHash: txHash + "caca",
+          txHash: txHash,
           parsedPayload: true,
         },
       }),

--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -49,7 +49,7 @@ const Tx = () => {
     () =>
       getClient().guardianNetwork.getVAAbyTxHash({
         query: {
-          txHash: txHash,
+          txHash: txHash + "caca",
           parsedPayload: true,
         },
       }),
@@ -110,7 +110,7 @@ const Tx = () => {
                   },
                   symbol: txData.symbol,
                   timestamp: new Date(txData.timestamp),
-                  tokenAmount: txData.amount,
+                  tokenAmount: txData.tokenAmount,
                   txHash: txData.txHash,
                   usdAmount: txData.usdAmount,
                 },

--- a/src/utils/fetchWithRPCsFallthrough.ts
+++ b/src/utils/fetchWithRPCsFallthrough.ts
@@ -305,11 +305,9 @@ export async function fetchWithRpcFallThrough(env: Environment, searchValue: str
             };
 
             const cctpResult = parseCCTPRelayerPayload(Buffer.from(payload.slice(2), "hex"));
-            const amount = "" + 100 * +cctpResult.amount; // this will later be formatted with 8 decimals
-            const fee = "" + 100 * +cctpResult.feeAmount; // this will later be formatted with 8 decimals
-            const toNativeAmount = "" + 100 * +cctpResult.toNativeAmount; // this will later be formatted with 8 decimals
-
-            const tokenAmount = "" + 0.000001 * +cctpResult.amount; // 6 decimals for USDC
+            const amount = "" + 0.000001 * +cctpResult.amount; // 6 decimals for USDC
+            const fee = "" + 0.000001 * +cctpResult.feeAmount; // 6 decimals for USDC
+            const toNativeAmount = "" + 0.000001 * +cctpResult.toNativeAmount; // 6 decimals for USDC
 
             return {
               amount,
@@ -328,11 +326,11 @@ export async function fetchWithRpcFallThrough(env: Environment, searchValue: str
               toAddress: cctpResult.toAddress,
               toChain: getCctpDomain(cctpResult.toDomain),
               tokenAddress: cctpResult.tokenAddress,
-              tokenAmount,
+              tokenAmount: amount,
               tokenChain: result.chainId,
               toNativeAmount,
               txHash: search,
-              usdAmount: tokenAmount,
+              usdAmount: amount,
             };
           }
           // default, no token-bridge nor cctp ones (can add other payload readers here)

--- a/src/utils/wh-connect-rpc.ts
+++ b/src/utils/wh-connect-rpc.ts
@@ -1,0 +1,104 @@
+import {
+  CHAIN_ID_AVAX,
+  CHAIN_ID_BSC,
+  CHAIN_ID_CELO,
+  CHAIN_ID_ETH,
+  CHAIN_ID_FANTOM,
+  CHAIN_ID_MOONBEAM,
+  CHAIN_ID_POLYGON,
+  CHAIN_ID_SUI,
+  ChainId,
+} from "@certusone/wormhole-sdk";
+
+const connectAddresses: any = {
+  MAINNET: {
+    [CHAIN_ID_ETH]: [
+      "000000000000000000000000cafd2f0a35a4459fa40c0517e17e6fa2939441ca",
+      "000000000000000000000000461a8878060aa45fa685732bff654ca1fdef2830",
+    ],
+    [CHAIN_ID_BSC]: [
+      "000000000000000000000000cafd2f0a35a4459fa40c0517e17e6fa2939441ca",
+      "000000000000000000000000461a8878060aa45fa685732bff654ca1fdef2830",
+    ],
+    [CHAIN_ID_POLYGON]: [
+      "000000000000000000000000cafd2f0a35a4459fa40c0517e17e6fa2939441ca",
+      "000000000000000000000000461a8878060aa45fa685732bff654ca1fdef2830",
+    ],
+    [CHAIN_ID_AVAX]: [
+      "000000000000000000000000cafd2f0a35a4459fa40c0517e17e6fa2939441ca",
+      "000000000000000000000000461a8878060aa45fa685732bff654ca1fdef2830",
+    ],
+    [CHAIN_ID_FANTOM]: [
+      "000000000000000000000000cafd2f0a35a4459fa40c0517e17e6fa2939441ca",
+      "000000000000000000000000461a8878060aa45fa685732bff654ca1fdef2830",
+    ],
+    [CHAIN_ID_CELO]: [
+      "000000000000000000000000cafd2f0a35a4459fa40c0517e17e6fa2939441ca",
+      "000000000000000000000000461a8878060aa45fa685732bff654ca1fdef2830",
+    ],
+    [CHAIN_ID_MOONBEAM]: [
+      "000000000000000000000000cafd2f0a35a4459fa40c0517e17e6fa2939441ca",
+      "000000000000000000000000461a8878060aa45fa685732bff654ca1fdef2830",
+    ],
+    [CHAIN_ID_SUI]: [
+      "c4c610707eab9b222996b075f7d07c7d9b07766ab7bcafef621fd53bbf089f4e",
+      "44cd5861a6732696d2122e5d1123c3b86c8146c2fe78fd957378fc9ce28b9c41",
+    ],
+  },
+  TESTNET: {
+    [CHAIN_ID_ETH]: ["000000000000000000000000e32b14c48e4b7c6825b855f231786fe5ba9ce014"],
+    [CHAIN_ID_BSC]: ["00000000000000000000000049a401f7fa594bc618a7a39b316b78e329620103"],
+    [CHAIN_ID_POLYGON]: ["000000000000000000000000953a2342496b15d69dec25c8e62274995e82d243"],
+    [CHAIN_ID_AVAX]: ["0000000000000000000000008369839932222c1ca3bc7d16f970c56f61993a44"],
+    [CHAIN_ID_FANTOM]: ["0000000000000000000000005122298f68341a088c5370d7678e13912e4ed378"],
+    [CHAIN_ID_CELO]: ["0000000000000000000000005c9da01cbf5088ee660b9701dc526c6e5df1c239"],
+    [CHAIN_ID_MOONBEAM]: ["000000000000000000000000a098368aaadc0fdf3e309cda710d7a5f8bdeecd9"],
+    [CHAIN_ID_SUI]: ["805094a77dc75a5c204e98995e5394612554fa5901a1adaf8ca31dac31dba3e5"],
+  },
+};
+export function isConnect(network: any, emitterChain: ChainId, fromAddress: string) {
+  const address = fromAddress.toLowerCase();
+  return connectAddresses[network][emitterChain]?.includes(address) ?? false;
+}
+
+export interface ConnectPayload {
+  payloadId: number; // == 1  // uint8
+  targetRelayerFee: string; // uint256
+  toNativeTokenAmount: string; // uint256
+  recipientWallet: string; // bytes32 as wormhole hex formatted addr
+}
+
+export function parseConnectPayload(payload: Buffer): ConnectPayload {
+  let index = 0;
+
+  // parse the payloadId
+  const payloadId = payload.readUint8(index);
+  index += 1;
+
+  // target relayer fee
+  const targetRelayerFee = BigInt(
+    "0x" + payload.slice(index, index + 32).toString("hex"),
+  ).toString(); // uint256
+  index += 32;
+
+  // amount of tokens to convert to native assets
+  const toNativeTokenAmount = BigInt(
+    "0x" + payload.slice(index, index + 32).toString("hex"),
+  ).toString(); // uint256
+  index += 32;
+
+  // recipient of the transferred tokens and native assets
+  const recipientWallet = payload.slice(index, index + 32).toString("hex");
+
+  index += 32;
+
+  if (index !== payload.length) {
+    throw new Error("invalid message length");
+  }
+  return {
+    payloadId,
+    targetRelayerFee,
+    recipientWallet,
+    toNativeTokenAmount,
+  };
+}


### PR DESCRIPTION
### Description

This PR adds support to see Wormhole-Connect related information on RPCs (this means, when a user just makes a transaction and there is no VAA emitted yet)

Also, it fixes some bugs on non-vaa transactions (for example: SUI transactions were crashing the app, and redeem amount sometimes was showing a ridiculously high number)

### Screenshot

![PrScreenshot](https://github.com/XLabs/wormscan-ui/assets/41705567/aa2c0d02-8de9-489d-8230-a4cc4fe8f4e2)

