### PR TITLE
Fix CCTP amounts when tokenAmount is not there

### DIFF
--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -203,13 +203,23 @@ const Tx = () => {
 
         // check CCTP
         if (txResponse?.standardizedProperties?.appIds?.includes("CCTP_WORMHOLE_INTEGRATION")) {
-          // if it is, get relayer information
+          // if the amount is not there, we get it from the payload
+          //     (we assume 6 decimals because its always USDC)
+          if (!txResponse.tokenAmount && !!txResponse.payload?.amount) {
+            txResponse.tokenAmount = String(+txResponse.payload?.amount * 0.000001);
+            txResponse.standardizedProperties.amount = String(+txResponse.payload?.amount * 100);
+            if (!txResponse.symbol) {
+              txResponse.symbol = "USDC";
+            }
+          }
+
+          // get CCTP relayer information
           const relayResponse = await getClient().search.getCctpRelay({
             txHash: parseTx({ value: txResponse.txHash, chainId: 2 }),
             network: network,
           });
 
-          // and add Redeem Txn information to the tx response
+          // add Redeem Txn information to the tx response
           if (relayResponse?.to?.txHash) {
             const cctpDestination: GlobalTxOutput["destinationTx"] = {
               chainId: relayResponse.to.chainId,


### PR DESCRIPTION
### Description

Sometimes the API respond without a `tokenAmount` or `symbol` for CCTP transactions.

This PR patches those cases getting that info from the payload and assuming USDC with 6 decimals.

![scrr](https://github.com/XLabs/wormscan-ui/assets/41705567/e9e823a6-4695-4b14-a48f-73e583f97a57)
