### PR TITLE
Better tx handling and cctp endpoint fix

### DIFF
--- a/src/api/search/Search.ts
+++ b/src/api/search/Search.ts
@@ -69,9 +69,13 @@ export class Search {
     txHash: string;
     network: Network;
   }): Promise<CctpRelayOutput> {
-    let cctpURL = "https://relayer.stable.io/v1/relays?txHash=";
+    // Remove CORS_PROXY when the endpoint stops responding with CORS err.
+    const uu = new Date().getTime();
+    const CORS_PROXY = `https://nextjs-cors-anywhere.vercel.app/api?preventcache=${uu}&endpoint=`;
+
+    let cctpURL = CORS_PROXY + "https://relayer.stable.io/v1/relays?txHash=";
     if (network === "TESTNET") {
-      cctpURL = "https://relayer.dev.stable.io/v1/relays?txHash=";
+      cctpURL = CORS_PROXY + "https://relayer.dev.stable.io/v1/relays?txHash=";
     }
 
     try {


### PR DESCRIPTION
### Better Tx Handling

When a transaction is just made, the Portal Bridge and the Wormhole Connect apps have a link to come directly to the wormholescan to see the transaction.

The problem was: The tx was not always available when pressing on the 'see on wormholescan', that only works immediately if the chain its EVM, on other cases like Solana, the not found was being shown:

https://github.com/XLabs/wormscan-ui/assets/41705567/042e9f60-5864-4018-bd94-72d4cb39f8ca

☝🏼

This PR fixes those cases by retrying at least 4 times before sending the user to the not found page. That fixes the majority of not found for recently made transactions:

👇🏼 

https://github.com/XLabs/wormscan-ui/assets/41705567/7fcd57b4-7fd8-4280-986d-d0341fd812e4

---

### CCTP endpoint fix

The endpoints "https://relayer.stable.io/v1/relays" and "https://relayer.dev.stable.io/v1/relays" are not working correctly on production. This PR makes a patch for them to work until they are officially fixed.
