### PR TITLE
Add analytics tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wormscan-ui",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "private": true,
   "source": "src/index.html",
   "scripts": {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -12,4 +12,12 @@ const analytics = Analytics({
   ],
 });
 
+analytics.on("page", pageView => {
+  console.log("page view", pageView?.payload?.properties?.title);
+});
+
+analytics.on("track", trackEvent => {
+  console.log("event track", trackEvent?.payload?.event, trackEvent?.payload?.properties);
+});
+
 export default analytics;

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -12,8 +12,4 @@ const analytics = Analytics({
   ],
 });
 
-analytics.on("page", pageView => {
-  console.log(process.env.WORMSCAN_ANALYTICS_ID, pageView);
-});
-
 export default analytics;

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -8,6 +8,9 @@ const analytics = Analytics({
   plugins: [
     googleAnalytics({
       measurementIds: [process.env.WORMSCAN_ANALYTICS_ID],
+      gtagConfig: {
+        anonymize_ip: true,
+      },
     }),
   ],
 });

--- a/src/components/molecules/CrossChainChart/Chart.tsx
+++ b/src/components/molecules/CrossChainChart/Chart.tsx
@@ -10,6 +10,7 @@ import { ChainId } from "src/api";
 import { CrossChainActivity, CrossChainBy } from "src/api/guardian-network/types";
 import { StickyInfo } from "./StickyInfo";
 import { processData } from "./chartUtils";
+import analytics from "src/analytics";
 
 interface IChartChain {
   itemHeight: number;
@@ -26,6 +27,7 @@ type Props = {
   data: CrossChainActivity;
   selectedType: CrossChainBy;
   selectedDestination: "sources" | "destinations";
+  selectedTimeRange: string;
 };
 export type Info = { percentage: number; volume: number };
 
@@ -43,7 +45,13 @@ const getAbbreviatedName = ({
   return chainName;
 };
 
-export const Chart = ({ currentNetwork, data, selectedType, selectedDestination }: Props) => {
+export const Chart = ({
+  currentNetwork,
+  data,
+  selectedType,
+  selectedDestination,
+  selectedTimeRange,
+}: Props) => {
   const [isShowingOthers, setIsShowingOthers] = useState(false);
   const [chartData, setChartData] = useState(processData(data, false, selectedDestination));
 
@@ -331,7 +339,16 @@ export const Chart = ({ currentNetwork, data, selectedType, selectedDestination 
       <div
         key={item.chain}
         className={`cross-chain-chart-side-item selectable ${isSourcesSelected ? "left" : "right"}`}
-        onClick={() => setSelectedChain(item.chain)}
+        onClick={() => {
+          analytics.track("crossChainChart", {
+            chain: item.chain,
+            network: currentNetwork,
+            selectedType,
+            selectedDestination,
+            selectedTimeRange,
+          });
+          setSelectedChain(item.chain);
+        }}
         data-network={currentNetwork}
         data-percentage={item.percentage}
         data-selected={selectedChain === item.chain}
@@ -367,7 +384,17 @@ export const Chart = ({ currentNetwork, data, selectedType, selectedDestination 
         <span className="chain-infoTxt onlyBig">{getAmount(item.volume)}</span>
       </div>
     ),
-    [MARGIN_SIZE_ELEMENTS, getAmount, isDesktop, isSourcesSelected, selectedChain, currentNetwork],
+    [
+      isSourcesSelected,
+      currentNetwork,
+      selectedChain,
+      MARGIN_SIZE_ELEMENTS,
+      getAmount,
+      isDesktop,
+      selectedType,
+      selectedDestination,
+      selectedTimeRange,
+    ],
   );
 
   return (

--- a/src/components/molecules/CrossChainChart/index.tsx
+++ b/src/components/molecules/CrossChainChart/index.tsx
@@ -123,6 +123,7 @@ const CrossChainChart = () => {
               data={data}
               selectedDestination={selectedDestination}
               selectedType={selectedType}
+              selectedTimeRange={selectedTimeRange.value}
             />
           )}
         </>

--- a/src/components/molecules/Header/Search/index.tsx
+++ b/src/components/molecules/Header/Search/index.tsx
@@ -4,12 +4,15 @@ import { useTranslation } from "react-i18next";
 import { useNavigateCustom } from "src/utils/hooks/useNavigateCustom";
 import { getClient } from "src/api/Client";
 import SearchBar from "../../SearchBar";
+import analytics from "src/analytics";
+import { useEnvironment } from "src/context/EnvironmentContext";
 
 interface FormData {
   search: { value: string };
 }
 
 const Search = () => {
+  const { environment } = useEnvironment();
   const navigate = useNavigateCustom();
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -42,6 +45,9 @@ const Search = () => {
 
   const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    analytics.track("search", {
+      network: environment.network,
+    });
 
     const { search } = e.target as typeof e.target & FormData;
     let { value } = search;

--- a/src/components/molecules/TransactionHistory/index.tsx
+++ b/src/components/molecules/TransactionHistory/index.tsx
@@ -3,6 +3,8 @@ import { ToggleGroup } from "src/components/atoms";
 import { DateRange } from "src/api/guardian-network/types";
 import { TransactionHistoryChart } from "..";
 import "./styles.scss";
+import analytics from "src/analytics";
+import { useEnvironment } from "src/context/EnvironmentContext";
 
 const RANGE_LIST = [
   { label: "1D", value: "day", ariaLabel: "One day" },
@@ -13,6 +15,7 @@ const RANGE_LIST = [
 ];
 
 const TransactionHistory = () => {
+  const { environment } = useEnvironment();
   const [selectedRange, setSelectedRange] = useState<DateRange>(RANGE_LIST[0].value as DateRange);
 
   return (
@@ -21,7 +24,13 @@ const TransactionHistory = () => {
         <div className="tx-title">Transaction History</div>
         <ToggleGroup
           value={selectedRange}
-          onValueChange={value => setSelectedRange(value)}
+          onValueChange={value => {
+            analytics.track("transactionHistory", {
+              selected: value,
+              network: environment.network,
+            });
+            setSelectedRange(value);
+          }}
           items={RANGE_LIST}
           ariaLabel="Select range"
           separatedOptions

--- a/src/components/molecules/TransactionHistory/index.tsx
+++ b/src/components/molecules/TransactionHistory/index.tsx
@@ -2,9 +2,9 @@ import { useState } from "react";
 import { ToggleGroup } from "src/components/atoms";
 import { DateRange } from "src/api/guardian-network/types";
 import { TransactionHistoryChart } from "..";
-import "./styles.scss";
-import analytics from "src/analytics";
 import { useEnvironment } from "src/context/EnvironmentContext";
+import analytics from "src/analytics";
+import "./styles.scss";
 
 const RANGE_LIST = [
   { label: "1D", value: "day", ariaLabel: "One day" },

--- a/src/components/organisms/SearchNotFound/Error400/index.tsx
+++ b/src/components/organisms/SearchNotFound/Error400/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import analytics from "src/analytics";
 import SearchNotFoundImage from "src/assets/search-not-found.svg";
 import { DISCORD_URL } from "src/consts";
 
@@ -7,6 +9,10 @@ type Props = {
 };
 
 const Error400 = ({ q, goHome }: Props) => {
+  useEffect(() => {
+    analytics.page({ title: "SEARCH_NOT_FOUND" });
+  }, []);
+
   return (
     <div className="error-page">
       <div className="error-page-container">

--- a/src/components/organisms/SearchNotFound/Error500/index.tsx
+++ b/src/components/organisms/SearchNotFound/Error500/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import analytics from "src/analytics";
 import AstronautImage from "src/assets/astronaut.svg";
 import Error500Image from "src/assets/error500.svg";
 
@@ -6,6 +8,10 @@ type Props = {
 };
 
 const Error500 = ({ goHome }: Props) => {
+  useEffect(() => {
+    analytics.page({ title: "ERROR_500" });
+  }, []);
+
   return (
     <div className="error-page error-page-bg-500">
       <div className="error-page-container">

--- a/src/components/organisms/SearchNotFound/Error502/index.tsx
+++ b/src/components/organisms/SearchNotFound/Error502/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import analytics from "src/analytics";
 import Error502Image from "src/assets/error502.svg";
 
 type Props = {
@@ -5,6 +7,10 @@ type Props = {
 };
 
 const Error502 = ({ goHome }: Props) => {
+  useEffect(() => {
+    analytics.page({ title: "ERROR_502" });
+  }, []);
+
   return (
     <div className="error-page">
       <div className="error-page-container">

--- a/src/components/organisms/SearchNotFound/Error503/index.tsx
+++ b/src/components/organisms/SearchNotFound/Error503/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import analytics from "src/analytics";
 import Error503Image from "src/assets/error503.svg";
 import { DISCORD_URL } from "src/consts";
 
@@ -6,6 +8,10 @@ type Props = {
 };
 
 const Error503 = ({ goHome }: Props) => {
+  useEffect(() => {
+    analytics.page({ title: "ERROR_503" });
+  }, []);
+
   return (
     <div className="error-page error-page-bg-503">
       <div className="error-page-container">

--- a/src/components/organisms/SearchNotFound/ErrorGeneral/index.tsx
+++ b/src/components/organisms/SearchNotFound/ErrorGeneral/index.tsx
@@ -1,7 +1,13 @@
+import { useEffect } from "react";
+import analytics from "src/analytics";
 import ErrorGeneralImage from "src/assets/errorGeneral.svg";
 import { DISCORD_URL } from "src/consts";
 
 const ErrorGeneral = () => {
+  useEffect(() => {
+    analytics.page({ title: "ERROR_GENERAL" });
+  }, []);
+
   const reloadPage = () => {
     window.location.reload();
   };

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -4,6 +4,7 @@ import { Loader } from "src/components/atoms";
 import { BaseLayout } from "src/layouts/BaseLayout";
 import { EnvironmentProvider } from "src/context/EnvironmentContext";
 import { ScrollControl } from "src/utils/scrollControl";
+import { AnalyticsLinkTracker } from "src/utils/analyticsLinkTracker";
 import ErrorBoundary from "src/utils/errorBoundary";
 
 const Home = lazy(() => import("../pages/Home"));
@@ -15,25 +16,27 @@ const Navigation = () => {
   return (
     <Router>
       <ScrollControl />
-      <EnvironmentProvider>
-        <ErrorBoundary>
-          <Suspense
-            fallback={
-              <BaseLayout>
-                <Loader />
-              </BaseLayout>
-            }
-          >
-            <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/txs" element={<Txs />} />
-              <Route path="/tx/:txHash" element={<Tx />} />
-              <Route path="/tx/:chainId/:emitter/:seq" element={<Tx />} />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </Suspense>
-        </ErrorBoundary>
-      </EnvironmentProvider>
+      <AnalyticsLinkTracker>
+        <EnvironmentProvider>
+          <ErrorBoundary>
+            <Suspense
+              fallback={
+                <BaseLayout>
+                  <Loader />
+                </BaseLayout>
+              }
+            >
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/txs" element={<Txs />} />
+                <Route path="/tx/:txHash" element={<Tx />} />
+                <Route path="/tx/:chainId/:emitter/:seq" element={<Tx />} />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </Suspense>
+          </ErrorBoundary>
+        </EnvironmentProvider>
+      </AnalyticsLinkTracker>
     </Router>
   );
 };

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -6,7 +6,7 @@ import analytics from "src/analytics";
 
 const NotFound = () => {
   useEffect(() => {
-    analytics.page({ title: "NOT_FOUND" });
+    analytics.page({ title: "NOT_FOUND_PAGE" });
   }, []);
 
   const navigate = useNavigateCustom();

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,8 +1,8 @@
+import { useEffect } from "react";
 import { BaseLayout } from "src/layouts/BaseLayout";
 import { useNavigateCustom } from "src/utils/hooks/useNavigateCustom";
-import "./styles.scss";
-import { useEffect } from "react";
 import analytics from "src/analytics";
+import "./styles.scss";
 
 const NotFound = () => {
   useEffect(() => {

--- a/src/pages/Tx/Information/Tabs/index.tsx
+++ b/src/pages/Tx/Information/Tabs/index.tsx
@@ -5,6 +5,7 @@ import OverviewIcon from "src/icons/OverviewIcon";
 import { Tooltip } from "src/components/atoms";
 import { BREAKPOINTS } from "src/consts";
 import "./styles.scss";
+import analytics from "src/analytics";
 
 type TabsProps = {
   isGenericRelayerTx: boolean;
@@ -50,14 +51,24 @@ const Tabs = ({
       <button
         className={`tx-tabs-trigger ${showOverview ? "tx-tabs-trigger-active" : ""}`}
         aria-label="Overview"
-        onClick={() => setShowOverview(true)}
+        onClick={() => {
+          analytics.track("txView", {
+            selected: "overview",
+          });
+          setShowOverview(true);
+        }}
       >
         OVERVIEW
       </button>
       <button
         className={`tx-tabs-trigger ${!showOverview ? "tx-tabs-trigger-active" : ""}`}
         aria-label="Raw data"
-        onClick={() => setShowOverview(false)}
+        onClick={() => {
+          analytics.track("txView", {
+            selected: "raw",
+          });
+          setShowOverview(false);
+        }}
       >
         RAW DATA
       </button>
@@ -81,7 +92,12 @@ const Tabs = ({
                   !showOverviewDetail ? "tx-tabs-sub-list-divider-button-active" : ""
                 }`}
                 aria-label="Overview"
-                onClick={() => setShowOverviewDetail(false)}
+                onClick={() => {
+                  analytics.track("overviewView", {
+                    selected: "overview",
+                  });
+                  setShowOverviewDetail(false);
+                }}
               >
                 <OverviewIcon height={24} width={24} />
               </button>
@@ -102,7 +118,12 @@ const Tabs = ({
                   showOverviewDetail ? "tx-tabs-sub-list-divider-button-active" : ""
                 }`}
                 aria-label="Details list"
-                onClick={() => setShowOverviewDetail(true)}
+                onClick={() => {
+                  analytics.track("overviewView", {
+                    selected: "details",
+                  });
+                  setShowOverviewDetail(true);
+                }}
               >
                 <ListBulletIcon height={24} width={24} />
               </button>

--- a/src/pages/Tx/Information/Tabs/index.tsx
+++ b/src/pages/Tx/Information/Tabs/index.tsx
@@ -4,8 +4,8 @@ import { useWindowSize } from "src/utils/hooks/useWindowSize";
 import OverviewIcon from "src/icons/OverviewIcon";
 import { Tooltip } from "src/components/atoms";
 import { BREAKPOINTS } from "src/consts";
-import "./styles.scss";
 import analytics from "src/analytics";
+import "./styles.scss";
 
 type TabsProps = {
   isGenericRelayerTx: boolean;

--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -34,6 +34,7 @@ import RelayerOverview from "./Overview/RelayerOverview";
 import RelayerDetails from "./Details/RelayerDetails";
 
 import "./styles.scss";
+import analytics from "src/analytics";
 
 interface Props {
   extraRawInfo: any;
@@ -225,6 +226,11 @@ const Information = ({ extraRawInfo, VAAData, txData, blockData }: Props) => {
     setLoadingRelayers(true);
     populateDeliveryLifecycleRecordByVaa(environment, vaa)
       .then((result: DeliveryLifecycleRecord) => {
+        analytics.track("txDetail", {
+          appIds: ["GENERIC_RELAYER"],
+          fromChain: result?.sourceChainId ?? "null",
+          toChain: result?.targetTransactions?.[0].targetChainId ?? "null",
+        });
         setGenericRelayerInfo(result);
         setLoadingRelayers(false);
       })

--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -15,6 +15,7 @@ import { formatUnits, parseAddress, parseTx } from "src/utils/crypto";
 import { formatDate } from "src/utils/date";
 import { formatNumber } from "src/utils/number";
 import { getChainName, getExplorerLink } from "src/utils/wormhole";
+import analytics from "src/analytics";
 import {
   DeliveryLifecycleRecord,
   isRedelivery,
@@ -34,7 +35,6 @@ import RelayerOverview from "./Overview/RelayerOverview";
 import RelayerDetails from "./Details/RelayerDetails";
 
 import "./styles.scss";
-import analytics from "src/analytics";
 
 interface Props {
   extraRawInfo: any;

--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -287,6 +287,15 @@ const Tx = () => {
             setExtraRawInfo(relayResponse);
           }
         }
+
+        if (!txResponse?.standardizedProperties?.appIds?.includes("GENERIC_RELAYER")) {
+          analytics.track("txDetail", {
+            appIds: txResponse?.standardizedProperties?.appIds ?? "null",
+            fromChain: txResponse?.emitterChain ?? "null",
+            toChain: txResponse?.standardizedProperties?.toChain ?? "null",
+          });
+        }
+
         return txResponse;
       });
 

--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -10,13 +10,13 @@ import { fetchWithRpcFallThrough } from "src/utils/fetchWithRPCsFallthrough";
 import { parseTx } from "src/utils/crypto";
 import { ChainId } from "src/api";
 import { getClient } from "src/api/Client";
+import analytics from "src/analytics";
 import { GlobalTxOutput, VAADetail } from "src/api/guardian-network/types";
 import { GetBlockData, GetTransactionsOutput } from "src/api/search/types";
 import { getGuardianSet } from "../../consts";
 import { Information } from "./Information";
 import { Top } from "./Top";
 import "./styles.scss";
-import analytics from "src/analytics";
 
 type ParsedVAA = VAADetail & { vaa: any; decodedVaa: any };
 

--- a/src/pages/Txs/index.tsx
+++ b/src/pages/Txs/index.tsx
@@ -17,8 +17,8 @@ import { GetTransactionsOutput } from "src/api/search/types";
 import { TxStatus } from "../../types";
 import { Information } from "./Information";
 import { Top } from "./Top";
-import "./styles.scss";
 import analytics from "src/analytics";
+import "./styles.scss";
 
 export interface TransactionOutput {
   VAAId: string;

--- a/src/utils/analyticsLinkTracker.tsx
+++ b/src/utils/analyticsLinkTracker.tsx
@@ -1,0 +1,31 @@
+import React, { ReactNode, useEffect } from "react";
+import analytics from "src/analytics";
+
+export const AnalyticsLinkTracker = (props: { children: ReactNode }) => {
+  useEffect(() => {
+    const handleLinkClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+
+      // Check if the clicked element is an <a> tag with an href attribute
+      if (target.tagName === "A" && target.getAttribute("href")) {
+        const href = target.getAttribute("href");
+
+        analytics.track("linkClicked", {
+          url: href,
+        });
+      }
+    };
+
+    // Detect left clicks and middle clicks on links
+    document.addEventListener("click", handleLinkClick);
+    document.addEventListener("auxclick", handleLinkClick);
+
+    // Cleanup the events listeners on component unmount
+    return () => {
+      document.removeEventListener("click", handleLinkClick);
+      document.removeEventListener("auxclick", handleLinkClick);
+    };
+  }, []);
+
+  return <>{props.children}</>;
+};


### PR DESCRIPTION
### Description

This PR adds analytics tracking for different events:

- cross chain chart usage
- transaction history usage
- links clicked
- searches done (not what is being search, only on what network)
- tx details views election (Overview/RawData and Overview/Detailed)
- tx details appId, source and target 