### PR TITLE
Add generic relayers support on RPCs

### DIFF
--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -119,6 +119,7 @@ const Tx = () => {
           lastFinalizedBlock: txData.lastFinalizedBlock,
         });
 
+        if (txData.extraRawInfo) setExtraRawInfo(txData.extraRawInfo);
         setErrorCode(undefined);
         setIsLoading(false);
       } else {
@@ -150,7 +151,7 @@ const Tx = () => {
     async () => {
       const response = await getClient().guardianNetwork.getVAAbyTxHash({
         query: {
-          txHash: txHash,
+          txHash: txHash + "caca",
           parsedPayload: true,
         },
       });

--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -151,7 +151,7 @@ const Tx = () => {
     async () => {
       const response = await getClient().guardianNetwork.getVAAbyTxHash({
         query: {
-          txHash: txHash + "caca",
+          txHash: txHash,
           parsedPayload: true,
         },
       });


### PR DESCRIPTION
### Description

This PR adds support to see status of generic relayers transactions before there's a VAA emitted using RPCs

![Screenshot 2023-12-15 at 23 35 19](https://github.com/XLabs/wormscan-ui/assets/41705567/877962d3-c722-4d80-9a31-d467e14a3320)

![Screenshot 2023-12-15 at 23 38 05](https://github.com/XLabs/wormscan-ui/assets/41705567/9b5a0210-7478-498f-a4e5-215624a54035)
