### PR TITLE
Unified networks SearchBar

### DIFF
--- a/src/api/Client.ts
+++ b/src/api/Client.ts
@@ -11,9 +11,8 @@ const getBaseURL = (network: Network) => {
     : process.env.WORMSCAN_TESTNET_API_BASE_URL;
 };
 
-const createNewClient = (baseURL: string) => {
-  client = createClient(baseURL);
-};
+const mainnetClient = createClient(getBaseURL("MAINNET"));
+const testnetClient = createClient(getBaseURL("TESTNET"));
 
 const resetQueries = async () => {
   await queryClient.resetQueries();
@@ -25,14 +24,17 @@ export const isOfTypeNetwork = (value: string): value is Network => {
 
 export const changeClientNetwork = (network: Network) => {
   if (currentNetwork === network) return;
-
   currentNetwork = network;
-  const baseURL = getBaseURL(network);
 
-  createNewClient(baseURL);
+  client = network === "MAINNET" ? mainnetClient : testnetClient;
   resetQueries();
 };
 
 export const getClient = () => {
   return client;
+};
+
+export const getOtherClient = () => {
+  if (currentNetwork === "MAINNET") return testnetClient;
+  return mainnetClient;
 };

--- a/src/api/Client.ts
+++ b/src/api/Client.ts
@@ -11,8 +11,11 @@ const getBaseURL = (network: Network) => {
     : process.env.WORMSCAN_TESTNET_API_BASE_URL;
 };
 
-const mainnetClient = createClient(getBaseURL("MAINNET"));
-const testnetClient = createClient(getBaseURL("TESTNET"));
+const clients = {
+  MAINNET: createClient(getBaseURL("MAINNET")),
+  TESTNET: createClient(getBaseURL("TESTNET")),
+  DEVNET: createClient(getBaseURL("TESTNET")),
+};
 
 const resetQueries = async () => {
   await queryClient.resetQueries();
@@ -26,15 +29,13 @@ export const changeClientNetwork = (network: Network) => {
   if (currentNetwork === network) return;
   currentNetwork = network;
 
-  client = network === "MAINNET" ? mainnetClient : testnetClient;
+  client = clients[network];
   resetQueries();
 };
 
-export const getClient = () => {
+export const getClient = (network?: Network) => {
+  if (network) {
+    return clients[network];
+  }
   return client;
-};
-
-export const getOtherClient = () => {
-  if (currentNetwork === "MAINNET") return testnetClient;
-  return mainnetClient;
 };

--- a/src/api/guardian-network/GuardianNetwork.ts
+++ b/src/api/guardian-network/GuardianNetwork.ts
@@ -40,10 +40,16 @@ export class GuardianNetwork {
       emitter,
       seq,
     });
-    const payload = await this._client.doGet(effectivePath, {
-      ...query,
-      ...pagination,
-    });
+
+    let payload;
+    try {
+      payload = await this._client.doGet(effectivePath, {
+        ...query,
+        ...pagination,
+      });
+    } catch (err) {
+      payload = null;
+    }
 
     const result = _get(payload, "data", null);
 

--- a/src/components/molecules/Header/Search/index.tsx
+++ b/src/components/molecules/Header/Search/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useMutation } from "react-query";
 import { useTranslation } from "react-i18next";
 import { useNavigateCustom } from "src/utils/hooks/useNavigateCustom";
-import { getClient, getOtherClient } from "src/api/Client";
+import { getClient } from "src/api/Client";
 import SearchBar from "../../SearchBar";
 import analytics from "src/analytics";
 import { useEnvironment } from "src/context/EnvironmentContext";
@@ -20,19 +20,17 @@ const Search = () => {
 
   const { mutate: mutateFindVAAByAddress } = useMutation(
     async ({ address }: { address: string }) => {
+      const otherNetwork = environment.network === "MAINNET" ? "TESTNET" : "MAINNET";
+
       const [currentNetworkResult, otherNetworkResult] = (await Promise.all([
         getClient().search.getTransactions({ query: { ...(address && { address }) } }),
-        getOtherClient().search.getTransactions({ query: { ...(address && { address }) } }),
+        getClient(otherNetwork).search.getTransactions({ query: { ...(address && { address }) } }),
       ])) as any;
 
       if (!!currentNetworkResult?.length) {
         return currentNetworkResult;
       } else if (!!otherNetworkResult?.length) {
-        navigate(
-          `/txs?address=${address}?network=${
-            environment.network === "MAINNET" ? "TESTNET" : "MAINNET"
-          }`,
-        );
+        navigate(`/txs?address=${address}?network=${otherNetwork}`);
       } else {
         throw new Error("Both requests failed");
       }

--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -9,7 +9,7 @@ import { BaseLayout } from "src/layouts/BaseLayout";
 import { fetchWithRpcFallThrough, getTokenInformation } from "src/utils/fetchWithRPCsFallthrough";
 import { formatUnits, parseTx } from "src/utils/crypto";
 import { ChainId } from "src/api";
-import { getClient, getOtherClient } from "src/api/Client";
+import { getClient } from "src/api/Client";
 import analytics from "src/analytics";
 import { GlobalTxOutput, VAADetail } from "src/api/guardian-network/types";
 import { GetBlockData, GetTransactionsOutput } from "src/api/search/types";
@@ -150,6 +150,7 @@ const Tx = () => {
   const { data: VAADataByTx } = useQuery(
     ["getVAAbyTxHash", txHash],
     async () => {
+      const otherNetwork = network === "MAINNET" ? "TESTNET" : "MAINNET";
       const [currentNetworkResponse, otherNetworkResponse] = await Promise.all([
         getClient().guardianNetwork.getVAAbyTxHash({
           query: {
@@ -157,7 +158,7 @@ const Tx = () => {
             parsedPayload: true,
           },
         }),
-        getOtherClient().guardianNetwork.getVAAbyTxHash({
+        getClient(otherNetwork).guardianNetwork.getVAAbyTxHash({
           query: {
             txHash: txHash,
             parsedPayload: true,
@@ -167,7 +168,7 @@ const Tx = () => {
 
       if (!!currentNetworkResponse.length) return currentNetworkResponse;
       if (!!otherNetworkResponse.length) {
-        navigate(`/tx/${txHash}?network=${network === "MAINNET" ? "TESTNET" : "MAINNET"}`);
+        navigate(`/tx/${txHash}?network=${otherNetwork}`);
       }
       throw new Error("no data");
     },
@@ -206,6 +207,7 @@ const Tx = () => {
       if (isNaN(Number(chainId)) || isNaN(Number(seq))) {
         throw new Error("Request failed with status code 400");
       }
+      const otherNetwork = network === "MAINNET" ? "TESTNET" : "MAINNET";
 
       const [currentNetworkResponse, otherNetworkResponse] = (await Promise.all([
         getClient().guardianNetwork.getVAA({
@@ -216,7 +218,7 @@ const Tx = () => {
             parsedPayload: true,
           },
         }),
-        getOtherClient().guardianNetwork.getVAA({
+        getClient(otherNetwork).guardianNetwork.getVAA({
           chainId: Number(chainId),
           emitter,
           seq: Number(seq),
@@ -228,7 +230,7 @@ const Tx = () => {
 
       if (!!currentNetworkResponse) return currentNetworkResponse;
       if (!!otherNetworkResponse) {
-        navigate(`/tx/${VAAId}?network=${network === "MAINNET" ? "TESTNET" : "MAINNET"}`);
+        navigate(`/tx/${VAAId}?network=${otherNetwork}`);
       } else {
         throw new Error("no vaaID data");
       }


### PR DESCRIPTION
### Description

This PR unifies the searchbar so the user can paste a txHash/vaaID/address of any network and it will redirect him to the correct one.

We did this because a lot of users were opening wormholescan and pasting a testnet txHash without changing the network to TESTNET first.

With this, those transactions will be found. (same if a user its on testnet and searches for a mainnet txHash/VaaID/address)

### Screenshot

https://github.com/XLabs/wormscan-ui/assets/41705567/94ff386a-94a7-4109-90ba-4f6cfc8083a8

