### PR TITLE
Analytics: track all urls and findRedeem

### DIFF
--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -419,11 +419,22 @@ const Information = ({
         newTxData.standardizedProperties.overwriteFee = formattedRelayerFee;
       }
 
+      analytics.track("findRedeem", {
+        chain: getChainName({ chainId: toChain, network: currentNetwork }),
+        network: currentNetwork,
+        found: true,
+      });
       setFoundRedeem(true);
+
       setTimeout(() => {
         setTxData(newTxData);
       }, 2000);
     } else {
+      analytics.track("findRedeem", {
+        chain: getChainName({ chainId: toChain, network: currentNetwork }),
+        network: currentNetwork,
+        found: false,
+      });
       setFoundRedeem(false);
     }
     setLoadingRedeem(false);

--- a/src/utils/analyticsLinkTracker.tsx
+++ b/src/utils/analyticsLinkTracker.tsx
@@ -4,15 +4,24 @@ import analytics from "src/analytics";
 export const AnalyticsLinkTracker = (props: { children: ReactNode }) => {
   useEffect(() => {
     const handleLinkClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
+      let target = event.target as HTMLElement;
 
-      // Check if the clicked element is an <a> tag with an href attribute
-      if (target.tagName === "A" && target.getAttribute("href")) {
-        const href = target.getAttribute("href");
+      // link can be clicked directly on target or on parent element (for dynamic urls)
+      while (target) {
+        // Check if the current element is an <a> tag with an href attribute
+        if (target.tagName === "A" && target.getAttribute("href")) {
+          const href = target.getAttribute("href");
 
-        analytics.track("linkClicked", {
-          selected: href,
-        });
+          analytics.track("linkClicked", {
+            selected: href,
+          });
+
+          // Exit the loop after tracking
+          break;
+        }
+
+        // Move up to the parent element
+        target = target.parentElement;
       }
     };
 


### PR DESCRIPTION
### Description

This PR makes a change so:
- every URL pressed on wormholescan gets detected (dynamic urls, for example, the ones that appear after a state change, were not being tracked)
- findRedeem event gets tracked with its info