### PR TITLE
Maintain chain selected on volume/txn change

### DIFF
--- a/src/components/molecules/CrossChainChart/Chart.tsx
+++ b/src/components/molecules/CrossChainChart/Chart.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Network } from "@certusone/wormhole-sdk";
 import { BREAKPOINTS } from "src/consts";
@@ -29,6 +29,7 @@ type Props = {
   selectedType: CrossChainBy;
   selectedDestination: "sources" | "destinations";
   selectedTimeRange: string;
+  prevChain: MutableRefObject<ChainId>;
 };
 export type Info = { percentage: number; volume: number };
 
@@ -52,27 +53,36 @@ export const Chart = ({
   selectedType,
   selectedDestination,
   selectedTimeRange,
+  prevChain,
 }: Props) => {
   const [isShowingOthers, setIsShowingOthers] = useState(false);
   const [chartData, setChartData] = useState(processData(data, false, selectedDestination));
 
   const [selectedChain, setSelectedChain] = useState(chartData[0]?.chain);
+  if (!prevChain?.current) {
+    prevChain.current = chartData[0]?.chain;
+  }
   const [selectedInfo, setSelectedInfo] = useState<Info>({
     percentage: chartData[0]?.percentage,
     volume: chartData[0]?.volume,
   });
 
   useEffect(() => {
+    const chainToSearch = prevChain?.current || selectedChain;
+
     let newChartData = processData(data, false, selectedDestination);
-    if (newChartData.find(a => a.chain === selectedChain)) {
+    if (newChartData.find(a => a.chain === chainToSearch)) {
       setIsShowingOthers(false);
     } else {
       setIsShowingOthers(true);
       newChartData = processData(data, true, selectedDestination);
     }
 
+    if (selectedChain !== chainToSearch) {
+      setSelectedChain(chainToSearch);
+    }
     setChartData(newChartData);
-  }, [data, selectedChain, selectedDestination]);
+  }, [data, prevChain, selectedChain, selectedDestination]);
 
   const [destinations, setDestinations] = useState([]);
   const [originChainsHeight, setOriginChainsHeight] = useState<IChartChain[]>([]);
@@ -264,6 +274,7 @@ export const Chart = ({
 
     if (!selectedItem) {
       setSelectedChain(chartData[0]?.chain);
+      prevChain.current = chartData[0]?.chain;
       return;
     }
 
@@ -284,7 +295,7 @@ export const Chart = ({
       percentage: selected.percentage,
       volume: selected.volume,
     });
-  }, [chartData, selectedChain]);
+  }, [chartData, prevChain, selectedChain]);
 
   useEffect(() => {
     if (size.width >= BREAKPOINTS.desktop && !isDesktop) setIsDesktop(true);
@@ -360,6 +371,7 @@ export const Chart = ({
             selectedTimeRange,
           });
           setSelectedChain(item.chain);
+          prevChain.current = item.chain;
         }}
         data-network={currentNetwork}
         data-percentage={item.percentage}
@@ -409,6 +421,7 @@ export const Chart = ({
       selectedType,
       selectedDestination,
       selectedTimeRange,
+      prevChain,
     ],
   );
 

--- a/src/components/molecules/CrossChainChart/index.tsx
+++ b/src/components/molecules/CrossChainChart/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "react-query";
 import { useEnvironment } from "src/context/EnvironmentContext";
@@ -9,6 +9,7 @@ import { getClient } from "src/api/Client";
 import { CrossChainBy } from "src/api/guardian-network/types";
 import { Chart } from "./Chart";
 import "./styles.scss";
+import { ChainId } from "src/api";
 
 const MAINNET_TYPE_LIST = [
   { label: i18n.t("home.crossChain.volume"), value: "notional", ariaLabel: "Volume" },
@@ -39,6 +40,7 @@ const CrossChainChart = () => {
     "sources",
   );
   const isSources = selectedDestination === "sources";
+  const prevChain = useRef<ChainId>(null);
 
   useEffect(() => {
     if (currentNetwork === "MAINNET") {
@@ -119,6 +121,7 @@ const CrossChainChart = () => {
             <Chart
               currentNetwork={currentNetwork}
               data={data}
+              prevChain={prevChain}
               selectedDestination={selectedDestination}
               selectedType={selectedType}
               selectedTimeRange={selectedTimeRange.value}


### PR DESCRIPTION
### Description

On the cross-chain-activity chart (aka sankey chart), when the user switched between "Volume/Transactions", the chain selected was always the first one instead of maintaining the chain that was previously selected. This PR changes that.

BEFORE

https://github.com/XLabs/wormscan-ui/assets/41705567/7fcd9f7f-7274-4266-ac5a-d8867e7e45cc

AFTER

https://github.com/XLabs/wormscan-ui/assets/41705567/7938c2b3-3815-4835-8c00-2cc411c30a40

