### PR TITLE
Tooltip for vaa id duplicated, Scroll added in filters

### DIFF
--- a/src/api/guardian-network/types.ts
+++ b/src/api/guardian-network/types.ts
@@ -159,6 +159,7 @@ export interface GetOperationsOutput {
   sequence: string;
   vaa: {
     guardianSetIndex: number;
+    isDuplicated: boolean;
     raw: string;
   };
   content: {

--- a/src/pages/Tx/Information/AdvancedView/Details/RelayerDetails/index.tsx
+++ b/src/pages/Tx/Information/AdvancedView/Details/RelayerDetails/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { CopyIcon } from "@radix-ui/react-icons";
+import { CopyIcon, InfoCircledIcon } from "@radix-ui/react-icons";
 import { RelayerOverviewProps } from "src/pages/Tx/Information/Overview/RelayerOverview";
 import { BlockchainIcon, Tooltip } from "src/components/atoms";
 import { CopyToClipboard } from "src/components/molecules";
@@ -34,6 +34,7 @@ const RelayerDetails = ({
   gasUsedText,
   guardianSignaturesCount,
   isDelivery,
+  isDuplicated,
   maxRefundText,
   parsedEmitterAddress,
   parsedVaa,
@@ -46,6 +47,7 @@ const RelayerDetails = ({
   totalGuardiansNeeded,
   VAAId,
 }: RelayerOverviewProps) => {
+  const extraWidthDuplicated = isDuplicated ? 53 : 30;
   const lineValueRef = useRef<HTMLDivElement>(null);
   const [lineValueWidth, setLineValueWidth] = useState<number>(0);
 
@@ -192,10 +194,19 @@ const RelayerDetails = ({
         <div className="tx-details-group-line">
           <div className="tx-details-group-line-key">VAA ID</div>
           <div className="tx-details-group-line-value">
-            <TruncateText containerWidth={lineValueWidth} text={VAAId} />
+            <TruncateText
+              containerWidth={lineValueWidth}
+              extraWidth={extraWidthDuplicated}
+              text={VAAId}
+            />
             <CopyToClipboard toCopy={VAAId}>
               <CopyIcon height={20} width={20} />
             </CopyToClipboard>
+            {isDuplicated && (
+              <Tooltip tooltip={<div>VAA ID duplicated</div>} type="info">
+                <InfoCircledIcon />
+              </Tooltip>
+            )}
           </div>
         </div>
 

--- a/src/pages/Tx/Information/AdvancedView/Details/index.tsx
+++ b/src/pages/Tx/Information/AdvancedView/Details/index.tsx
@@ -6,8 +6,8 @@ import { OverviewProps } from "src/pages/Tx/Information/Overview";
 import { CopyToClipboard } from "src/components/molecules";
 import { getChainName, getExplorerLink } from "src/utils/wormhole";
 import { TruncateText } from "src/utils/string";
-import "./styles.scss";
 import AddressInfoTooltip from "src/components/molecules/AddressInfoTooltip";
+import "./styles.scss";
 
 const Details = ({
   addressesInfo,
@@ -20,6 +20,7 @@ const Details = ({
   fromChainOrig,
   guardianSignaturesCount,
   isAttestation,
+  isDuplicated,
   isGatewaySource,
   isUnknownApp,
   originDateParsed,
@@ -43,6 +44,7 @@ const Details = ({
 }: OverviewProps) => {
   const extraWidthGatewaySource = isGatewaySource ? 125 : 30;
   const extraWidthUnknownApp = isUnknownApp ? 55 : 30;
+  const extraWidthDuplicated = isDuplicated ? 53 : 30;
   const lineValueRef = useRef<HTMLDivElement>(null);
   const [lineValueWidth, setLineValueWidth] = useState<number>(0);
 
@@ -218,10 +220,19 @@ const Details = ({
           <div className="tx-details-group-line-value">
             {VAAId ? (
               <>
-                <TruncateText containerWidth={lineValueWidth} text={VAAId} />
+                <TruncateText
+                  containerWidth={lineValueWidth}
+                  extraWidth={extraWidthDuplicated}
+                  text={VAAId}
+                />
                 <CopyToClipboard toCopy={VAAId}>
                   <CopyIcon height={20} width={20} />
                 </CopyToClipboard>
+                {isDuplicated && (
+                  <Tooltip tooltip={<div>VAA ID duplicated</div>} type="info">
+                    <InfoCircledIcon />
+                  </Tooltip>
+                )}
               </>
             ) : (
               "N/A"

--- a/src/pages/Tx/Information/Overview/RelayerOverview/index.tsx
+++ b/src/pages/Tx/Information/Overview/RelayerOverview/index.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownIcon, CheckboxIcon, CopyIcon } from "@radix-ui/react-icons";
+import { ArrowDownIcon, CheckboxIcon, CopyIcon, InfoCircledIcon } from "@radix-ui/react-icons";
 import { Network } from "@certusone/wormhole-sdk";
 import { DeliveryInstruction } from "@certusone/wormhole-sdk/lib/cjs/relayer";
 import { BlockchainIcon, Tooltip } from "src/components/atoms";
@@ -37,6 +37,7 @@ export type RelayerOverviewProps = {
   gasUsedText: () => string;
   guardianSignaturesCount: number;
   isDelivery: boolean;
+  isDuplicated: boolean;
   maxRefundText: () => string;
   parsedEmitterAddress: string;
   parsedVaa: any;
@@ -69,6 +70,7 @@ const RelayerOverview = ({
   gasUsedText,
   guardianSignaturesCount,
   isDelivery,
+  isDuplicated,
   maxRefundText,
   parsedEmitterAddress,
   parsedVaa,
@@ -316,7 +318,14 @@ const RelayerOverview = ({
               </div>
             </div>
             <div>
-              <div className="tx-overview-graph-step-title">VAA ID</div>
+              <div className="tx-overview-graph-step-title">
+                VAA ID
+                {isDuplicated && (
+                  <Tooltip tooltip={<div>VAA ID duplicated</div>} type="info">
+                    <InfoCircledIcon />
+                  </Tooltip>
+                )}
+              </div>
               <div className="tx-overview-graph-step-description">
                 <Tooltip maxWidth={false} tooltip={<div>{VAAId}</div>} type="info">
                   <p>{shortVaaId(VAAId)}</p>

--- a/src/pages/Tx/Information/Overview/index.tsx
+++ b/src/pages/Tx/Information/Overview/index.tsx
@@ -6,9 +6,9 @@ import WormIcon from "src/icons/wormIcon.svg";
 import { getChainName, getExplorerLink } from "src/utils/wormhole";
 import { shortAddress, shortVaaId } from "src/utils/crypto";
 import { TokenInfo } from "src/utils/metaMaskUtils";
-import "./styles.scss";
 import { IAddressInfo } from "src/utils/recoilStates";
 import AddressInfoTooltip from "src/components/molecules/AddressInfoTooltip";
+import "./styles.scss";
 
 export type OverviewProps = {
   addressesInfo?: IAddressInfo;
@@ -21,6 +21,7 @@ export type OverviewProps = {
   fromChainOrig?: ChainId | number;
   guardianSignaturesCount?: number;
   isAttestation?: boolean;
+  isDuplicated?: boolean;
   isGatewaySource?: boolean;
   isMayanOnly?: boolean;
   isUnknownApp?: boolean;
@@ -66,6 +67,7 @@ const Overview = ({
   fromChainOrig,
   guardianSignaturesCount,
   isAttestation,
+  isDuplicated,
   isGatewaySource,
   isMayanOnly,
   isUnknownApp,
@@ -271,7 +273,14 @@ const Overview = ({
             </div>
 
             <div>
-              <div className="tx-overview-graph-step-title">VAA ID</div>
+              <div className="tx-overview-graph-step-title">
+                VAA ID
+                {isDuplicated && (
+                  <Tooltip tooltip={<div>VAA ID duplicated</div>} type="info">
+                    <InfoCircledIcon />
+                  </Tooltip>
+                )}
+              </div>
               <div className="tx-overview-graph-step-description">
                 {VAAId ? (
                   <>

--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -85,6 +85,7 @@ const Information = ({ blockData, extraRawInfo, setTxData, data, isRPC }: Props)
 
   const totalGuardiansNeeded = currentNetwork === "MAINNET" ? 13 : 1;
   const vaa = data?.vaa;
+  const { isDuplicated } = data?.vaa || {};
   const guardianSignaturesCount = data?.decodedVaa?.guardianSignatures?.length || 0;
   const hasVAA = !!vaa;
 
@@ -298,6 +299,7 @@ const Information = ({ blockData, extraRawInfo, setTxData, data, isRPC }: Props)
     fromChainOrig,
     guardianSignaturesCount,
     isAttestation,
+    isDuplicated,
     isGatewaySource,
     isMayanOnly: appIds?.length === 1 && appIds.includes(MAYAN_APP_ID),
     isUnknownApp,
@@ -780,6 +782,7 @@ const Information = ({ blockData, extraRawInfo, setTxData, data, isRPC }: Props)
         gasUsedText,
         guardianSignaturesCount,
         isDelivery,
+        isDuplicated,
         maxRefundText,
         parsedEmitterAddress,
         parsedVaa,

--- a/src/pages/Txs/Information/Filters/index.tsx
+++ b/src/pages/Txs/Information/Filters/index.tsx
@@ -77,7 +77,7 @@ const ChainFilterMainnet = [
   ChainId.Oasis,
   ChainId.Optimism,
   ChainId.Polygon,
-  // ChainId.Scroll, TODO: add when exists a Scroll transaction
+  ChainId.Scroll,
   ChainId.Sei,
   ChainId.Solana,
   ChainId.Sui,
@@ -115,7 +115,7 @@ const ChainFilterTestnet = [
   ChainId.Oasis,
   ChainId.Optimism,
   ChainId.OptimismSepolia,
-  // ChainId.Scroll, TODO: add when exists a Scroll transaction
+  ChainId.Scroll,
   ChainId.Sei,
   ChainId.Sepolia,
   ChainId.Solana,


### PR DESCRIPTION
# Description #638 #652 

- Added tooltip for duplicate VAA ID.
- Chain Scroll added to txs filters.

![Screenshot 2024-05-02 102318](https://github.com/XLabs/wormscan-ui/assets/88043910/fed86997-9ba4-4e56-bf35-c0bbe1f0bbb2)
![Screenshot 2024-05-02 102342](https://github.com/XLabs/wormscan-ui/assets/88043910/1391e97b-7a74-46c6-bac9-d5dc034f4ae0)
![Screenshot 2024-05-02 102353](https://github.com/XLabs/wormscan-ui/assets/88043910/b0af5c5e-413e-42a5-a308-23d4b47c89bd)
