### PR TITLE
Refactor Standard Relayer handling

### DIFF
--- a/src/api/guardian-network/types.ts
+++ b/src/api/guardian-network/types.ts
@@ -1,5 +1,6 @@
 import { ChainId, PageRequest } from "src/api/model";
 import { IStatus } from "src/consts";
+import { DeliveryLifecycleRecord } from "src/utils/genericRelayerVaaUtils";
 
 export type Observation = {
   hash: string;
@@ -261,5 +262,6 @@ export interface GetOperationsOutput {
   isBigTransaction?: boolean;
   isDailyLimitExceeded?: boolean;
   transactionLimit?: number;
+  relayerInfo?: DeliveryLifecycleRecord;
 }
 [];

--- a/src/pages/Tx/Information/AdvancedView/Details/RelayerDetails/index.tsx
+++ b/src/pages/Tx/Information/AdvancedView/Details/RelayerDetails/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { CopyIcon, InfoCircledIcon } from "@radix-ui/react-icons";
-import { RelayerOverviewProps } from "src/pages/Tx/Information/Overview/RelayerOverview";
 import { BlockchainIcon, Tooltip } from "src/components/atoms";
 import { CopyToClipboard } from "src/components/molecules";
 import { getChainName, getExplorerLink } from "src/utils/wormhole";
@@ -14,9 +13,11 @@ import "../styles.scss";
 import AddressInfoTooltip from "src/components/molecules/AddressInfoTooltip";
 import { ARKHAM_CHAIN_NAME } from "src/utils/arkham";
 import { ChainId } from "src/api";
+import { RelayerOverviewProps } from "src/utils/genericRelayerVaaUtils";
+import { useRecoilState } from "recoil";
+import { addressesInfoState } from "src/utils/recoilStates";
 
 const RelayerDetails = ({
-  addressesInfo,
   budgetText,
   copyBudgetText,
   currentNetwork,
@@ -47,6 +48,8 @@ const RelayerDetails = ({
   totalGuardiansNeeded,
   VAAId,
 }: RelayerOverviewProps) => {
+  const [addressesInfo] = useRecoilState(addressesInfoState);
+
   const extraWidthDuplicated = isDuplicated ? 53 : 30;
   const lineValueRef = useRef<HTMLDivElement>(null);
   const [lineValueWidth, setLineValueWidth] = useState<number>(0);

--- a/src/pages/Tx/Information/AdvancedView/Details/index.tsx
+++ b/src/pages/Tx/Information/AdvancedView/Details/index.tsx
@@ -8,9 +8,10 @@ import { getChainName, getExplorerLink } from "src/utils/wormhole";
 import { TruncateText } from "src/utils/string";
 import AddressInfoTooltip from "src/components/molecules/AddressInfoTooltip";
 import "./styles.scss";
+import { useRecoilState } from "recoil";
+import { addressesInfoState } from "src/utils/recoilStates";
 
 const Details = ({
-  addressesInfo,
   amountSent,
   amountSentUSD,
   currentNetwork,
@@ -42,6 +43,7 @@ const Details = ({
   totalGuardiansNeeded,
   VAAId,
 }: OverviewProps) => {
+  const [addressesInfo] = useRecoilState(addressesInfoState);
   const extraWidthGatewaySource = isGatewaySource ? 125 : 30;
   const extraWidthUnknownApp = isUnknownApp ? 55 : 30;
   const extraWidthDuplicated = isDuplicated ? 53 : 30;

--- a/src/pages/Tx/Information/AdvancedView/index.tsx
+++ b/src/pages/Tx/Information/AdvancedView/index.tsx
@@ -1,4 +1,3 @@
-import { JsonView } from "react-json-view-lite";
 import { CopyIcon, TriangleDownIcon } from "@radix-ui/react-icons";
 import { parseVaa } from "@certusone/wormhole-sdk";
 import {
@@ -38,7 +37,10 @@ const AdvancedView = ({
   const [showDetails, setShowDetails] = useLocalStorage<boolean>("showDetails", true);
   const [showJson, setShowJson] = useLocalStorage<boolean>("showJson", false);
   const payload = data?.content?.payload;
-  const dataNoPayload = JSON.parse(JSON.stringify(data)) as GetOperationsOutput;
+
+  const noRelayerData = { ...data, relayerInfo: null as any };
+  const dataNoPayload = JSON.parse(JSON.stringify(noRelayerData)) as GetOperationsOutput;
+  delete dataNoPayload.relayerInfo;
   if (dataNoPayload.content) dataNoPayload.content.payload = undefined;
   if (dataNoPayload.decodedVaa) dataNoPayload.decodedVaa = undefined;
 

--- a/src/pages/Tx/Information/Overview/RelayerOverview/index.tsx
+++ b/src/pages/Tx/Information/Overview/RelayerOverview/index.tsx
@@ -1,6 +1,4 @@
 import { ArrowDownIcon, CheckboxIcon, CopyIcon, InfoCircledIcon } from "@radix-ui/react-icons";
-import { Network } from "@certusone/wormhole-sdk";
-import { DeliveryInstruction } from "@certusone/wormhole-sdk/lib/cjs/relayer";
 import { BlockchainIcon, Tooltip } from "src/components/atoms";
 import { CopyToClipboard } from "src/components/molecules";
 import RelayIcon from "src/icons/relayIcon.svg";
@@ -13,46 +11,14 @@ import {
 import { formatDate } from "src/utils/date";
 import "../styles.scss";
 import { AutomaticRelayOutput } from "src/api/search/types";
-import { IAddressInfo } from "src/utils/recoilStates";
+import { addressesInfoState } from "src/utils/recoilStates";
 import AddressInfoTooltip from "src/components/molecules/AddressInfoTooltip";
 import { ARKHAM_CHAIN_NAME } from "src/utils/arkham";
 import { ChainId } from "src/api";
-
-export type RelayerOverviewProps = {
-  addressesInfo?: IAddressInfo;
-  budgetText: () => string;
-  copyBudgetText: () => string;
-  currentNetwork: Network;
-  decodeExecution: any;
-  deliveryAttempt: string;
-  deliveryInstruction: DeliveryInstruction;
-  deliveryParsedRefundAddress: string;
-  deliveryParsedRefundProviderAddress: string;
-  deliveryParsedSenderAddress: string;
-  deliveryParsedSourceProviderAddress: string;
-  deliveryParsedTargetAddress: string;
-  deliveryStatus: AutomaticRelayOutput;
-  fromChain: number;
-  gasUsed: number;
-  gasUsedText: () => string;
-  guardianSignaturesCount: number;
-  isDelivery: boolean;
-  isDuplicated: boolean;
-  maxRefundText: () => string;
-  parsedEmitterAddress: string;
-  parsedVaa: any;
-  receiverValueText: () => string;
-  refundStatus: string;
-  refundText: () => string;
-  resultLog: string;
-  sourceTxHash: string;
-  targetTxTimestamp: number;
-  totalGuardiansNeeded: number;
-  VAAId: string;
-};
+import { RelayerOverviewProps } from "src/utils/genericRelayerVaaUtils";
+import { useRecoilState } from "recoil";
 
 const RelayerOverview = ({
-  addressesInfo,
   budgetText,
   copyBudgetText,
   currentNetwork,
@@ -83,6 +49,8 @@ const RelayerOverview = ({
   totalGuardiansNeeded,
   VAAId,
 }: RelayerOverviewProps) => {
+  const [addressesInfo] = useRecoilState(addressesInfoState);
+
   const renderDeliveryStatus = (deliveryStatus: AutomaticRelayOutput) => {
     return (
       <div className={`tx-overview-graph-step-data-container`}>

--- a/src/pages/Tx/Information/Overview/index.tsx
+++ b/src/pages/Tx/Information/Overview/index.tsx
@@ -6,12 +6,12 @@ import WormIcon from "src/icons/wormIcon.svg";
 import { getChainName, getExplorerLink } from "src/utils/wormhole";
 import { shortAddress, shortVaaId } from "src/utils/crypto";
 import { TokenInfo } from "src/utils/metaMaskUtils";
-import { IAddressInfo } from "src/utils/recoilStates";
 import AddressInfoTooltip from "src/components/molecules/AddressInfoTooltip";
+import { useRecoilState } from "recoil";
+import { addressesInfoState } from "src/utils/recoilStates";
 import "./styles.scss";
 
 export type OverviewProps = {
-  addressesInfo?: IAddressInfo;
   amountSent?: string;
   amountSentUSD?: string;
   currentNetwork?: Network;
@@ -57,7 +57,6 @@ const NotFinalDestinationTooltip = () => (
 );
 
 const Overview = ({
-  addressesInfo,
   amountSent,
   amountSentUSD,
   currentNetwork,
@@ -90,6 +89,7 @@ const Overview = ({
   totalGuardiansNeeded,
   VAAId,
 }: OverviewProps) => {
+  const [addressesInfo] = useRecoilState(addressesInfoState);
   return (
     <div className="tx-overview">
       <div className="tx-overview-graph">

--- a/src/utils/genericRelayerVaaUtils.ts
+++ b/src/utils/genericRelayerVaaUtils.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import { ChainId, ParsedVaa, parseVaa } from "@certusone/wormhole-sdk";
+import { ChainId, Network, ParsedVaa, parseVaa } from "@certusone/wormhole-sdk";
 import {
   DeliveryInstruction,
   RedeliveryInstruction,
@@ -19,6 +19,38 @@ export type WormholeTransaction = {
   txHash: string;
 };
 
+export type RelayerOverviewProps = {
+  budgetText: () => string;
+  copyBudgetText: () => string;
+  currentNetwork: Network;
+  decodeExecution: any;
+  deliveryAttempt: string;
+  deliveryInstruction: DeliveryInstruction;
+  deliveryParsedRefundAddress: string;
+  deliveryParsedRefundProviderAddress: string;
+  deliveryParsedSenderAddress: string;
+  deliveryParsedSourceProviderAddress: string;
+  deliveryParsedTargetAddress: string;
+  deliveryStatus: AutomaticRelayOutput;
+  fromChain: number;
+  gasUsed: number;
+  gasUsedText: () => string;
+  guardianSignaturesCount: number;
+  isDelivery: boolean;
+  isDuplicated: boolean;
+  maxRefundText: () => string;
+  parsedEmitterAddress: string;
+  parsedVaa: any;
+  receiverValueText: () => string;
+  refundStatus: string;
+  refundText: () => string;
+  resultLog: string;
+  sourceTxHash: string;
+  targetTxTimestamp: number;
+  totalGuardiansNeeded: number;
+  VAAId: string;
+};
+
 export type DeliveryLifecycleRecord = {
   sourceTxHash?: string;
   sourceTxReceipt?: ethers.providers.TransactionReceipt;
@@ -32,6 +64,7 @@ export type DeliveryLifecycleRecord = {
     targetChainId?: ChainId;
     targetTxTimestamp?: number;
   };
+  props?: RelayerOverviewProps;
 };
 
 export async function populateDeliveryLifecycleRecordByVaa(


### PR DESCRIPTION
### Description

This PR refactors the way wormholescan handles standard relayer transactions.

Originally, all the relayers logic was 100% frontend, so we needed to get some information with the API and from there get everything else, so all the logic ended up being in a child component instead of the one with all the txn logic (`Tx`).

Nowadays we can get everything we need from the API and the logic had to be where everything else is.

With this refactor the standard relayer transactions are not going to show a Loader anymore. It will load everything at the same time. It also should fix some inconsistencies with the Arkham addresses tooltip.