### PR TITLE
Add Portal NFTs initial support

### DIFF
--- a/src/api/guardian-network/types.ts
+++ b/src/api/guardian-network/types.ts
@@ -150,6 +150,15 @@ export interface GetOperationsInput {
   vaaID?: string;
 }
 
+export interface INFTInfo {
+  description?: string;
+  external_url?: string;
+  image?: string;
+  name?: string;
+  uri?: string;
+  tokenId?: number;
+}
+
 export interface GetOperationsOutput {
   id: string;
   emitterChain: number;
@@ -192,12 +201,16 @@ export interface GetOperationsOutput {
         };
       };
       transceiverMessage?: any;
-      // ---     ---
 
       // --- Attestation ---
       symbol?: string;
       name?: string;
       decimals?: number;
+
+      // --- NFTs ---
+      uri?: string;
+      tokenId?: number;
+      nftInfo?: INFTInfo;
     };
     standarizedProperties: {
       appIds: string[];

--- a/src/pages/Tx/Information/AdvancedView/Details/index.tsx
+++ b/src/pages/Tx/Information/AdvancedView/Details/index.tsx
@@ -24,6 +24,7 @@ const Details = ({
   isDuplicated,
   isGatewaySource,
   isUnknownApp,
+  nftInfo,
   originDateParsed,
   parsedDestinationAddress,
   parsedEmitterAddress,
@@ -171,32 +172,74 @@ const Details = ({
             )}
           </div>
         </div>
-        <div className="tx-details-group-line">
-          <div className="tx-details-group-line-key">{isAttestation ? "Token" : "Amount"}</div>
-          <div className="tx-details-group-line-value">
-            {tokenAmount ? (
-              <>
-                {!isAttestation ? amountSent : ""}{" "}
-                {sourceSymbol ? (
+        {nftInfo ? (
+          <>
+            {nftInfo.name && (
+              <div className="tx-details-group-line">
+                <div className="tx-details-group-line-key">Name</div>
+                <div className="tx-details-group-line-value">
+                  <a href={nftInfo.image} target="_blank" rel="noopener noreferrer">
+                    {nftInfo.name}
+                  </a>
+                </div>
+              </div>
+            )}
+
+            {nftInfo.external_url && (
+              <div className="tx-details-group-line">
+                <div className="tx-details-group-line-key">External URL</div>
+                <div className="tx-details-group-line-value">
+                  <a href={nftInfo.external_url} target="_blank" rel="noopener noreferrer">
+                    {nftInfo.external_url}
+                  </a>
+                </div>
+              </div>
+            )}
+
+            {nftInfo.tokenId && (
+              <div className="tx-details-group-line">
+                <div className="tx-details-group-line-key">Token ID</div>
+                <div className="tx-details-group-line-value">{nftInfo.tokenId}</div>
+              </div>
+            )}
+
+            {nftInfo.description && (
+              <div className="tx-details-group-line">
+                <div className="tx-details-group-line-key">Description</div>
+                <div className="tx-details-group-line-value">{nftInfo.description}</div>
+              </div>
+            )}
+          </>
+        ) : (
+          <>
+            <div className="tx-details-group-line">
+              <div className="tx-details-group-line-key">{isAttestation ? "Token" : "Amount"}</div>
+              <div className="tx-details-group-line-value">
+                {tokenAmount ? (
                   <>
-                    {sourceTokenLink ? (
-                      <a href={sourceTokenLink} target="_blank" rel="noopener noreferrer">
-                        {sourceSymbol}
-                      </a>
+                    {!isAttestation ? amountSent : ""}{" "}
+                    {sourceSymbol ? (
+                      <>
+                        {sourceTokenLink ? (
+                          <a href={sourceTokenLink} target="_blank" rel="noopener noreferrer">
+                            {sourceSymbol}
+                          </a>
+                        ) : (
+                          <span>{sourceSymbol}</span>
+                        )}
+                        {amountSentUSD && `(${amountSentUSD} USD)`}
+                      </>
                     ) : (
-                      <span>{sourceSymbol}</span>
+                      "N/A"
                     )}
-                    {amountSentUSD && `(${amountSentUSD} USD)`}
                   </>
                 ) : (
                   "N/A"
                 )}
-              </>
-            ) : (
-              "N/A"
-            )}
-          </div>
-        </div>
+              </div>
+            </div>
+          </>
+        )}
       </div>
       <div className="tx-details-group">
         <div className="tx-details-group-line">
@@ -340,46 +383,48 @@ const Details = ({
               )}
             </div>
           </div>
-          <div className="tx-details-group-line">
-            <div className="tx-details-group-line-key">
-              {isAttestation ? "Target Token" : "Redeem Amount"}
-            </div>
-            <div className="tx-details-group-line-value">
-              {Number(fee) ? (
-                <>
-                  {!isAttestation ? redeemedAmount : ""}{" "}
-                  {targetSymbol &&
-                    (targetTokenLink ? (
-                      <a href={targetTokenLink} target="_blank" rel="noopener noreferrer">
-                        {targetSymbol}
-                      </a>
-                    ) : (
-                      <span>{targetSymbol}</span>
-                    ))}
-                </>
-              ) : tokenAmount ? (
-                <>
-                  {!isAttestation ? amountSent : ""}{" "}
-                  {targetSymbol ? (
-                    <>
-                      {targetTokenLink ? (
+          {!nftInfo && (
+            <div className="tx-details-group-line">
+              <div className="tx-details-group-line-key">
+                {isAttestation ? "Target Token" : "Redeem Amount"}
+              </div>
+              <div className="tx-details-group-line-value">
+                {Number(fee) ? (
+                  <>
+                    {!isAttestation ? redeemedAmount : ""}{" "}
+                    {targetSymbol &&
+                      (targetTokenLink ? (
                         <a href={targetTokenLink} target="_blank" rel="noopener noreferrer">
                           {targetSymbol}
                         </a>
                       ) : (
                         <span>{targetSymbol}</span>
-                      )}
-                      {amountSentUSD && `(${amountSentUSD} USD)`}
-                    </>
-                  ) : (
-                    "N/A"
-                  )}
-                </>
-              ) : (
-                "N/A"
-              )}
+                      ))}
+                  </>
+                ) : tokenAmount ? (
+                  <>
+                    {!isAttestation ? amountSent : ""}{" "}
+                    {targetSymbol ? (
+                      <>
+                        {targetTokenLink ? (
+                          <a href={targetTokenLink} target="_blank" rel="noopener noreferrer">
+                            {targetSymbol}
+                          </a>
+                        ) : (
+                          <span>{targetSymbol}</span>
+                        )}
+                        {amountSentUSD && `(${amountSentUSD} USD)`}
+                      </>
+                    ) : (
+                      "N/A"
+                    )}
+                  </>
+                ) : (
+                  "N/A"
+                )}
+              </div>
             </div>
-          </div>
+          )}
           {showMetaMaskBtn && (
             <div className="tx-details-group-line">
               <div className="tx-details-group-line-key"></div>

--- a/src/pages/Tx/Information/Overview/index.tsx
+++ b/src/pages/Tx/Information/Overview/index.tsx
@@ -9,6 +9,7 @@ import { TokenInfo } from "src/utils/metaMaskUtils";
 import AddressInfoTooltip from "src/components/molecules/AddressInfoTooltip";
 import { useRecoilState } from "recoil";
 import { addressesInfoState } from "src/utils/recoilStates";
+import { INFTInfo } from "src/api/guardian-network/types";
 import "./styles.scss";
 
 export type OverviewProps = {
@@ -25,6 +26,7 @@ export type OverviewProps = {
   isGatewaySource?: boolean;
   isMayanOnly?: boolean;
   isUnknownApp?: boolean;
+  nftInfo?: INFTInfo;
   originDateParsed?: string;
   parsedDestinationAddress?: string;
   parsedEmitterAddress?: string;
@@ -70,6 +72,7 @@ const Overview = ({
   isGatewaySource,
   isMayanOnly,
   isUnknownApp,
+  nftInfo,
   originDateParsed,
   parsedDestinationAddress,
   parsedEmitterAddress,
@@ -110,7 +113,7 @@ const Overview = ({
             )}
           </div>
           <div className={`tx-overview-graph-step-data-container`}>
-            {!isMayanOnly && (
+            {!isMayanOnly && !nftInfo && (
               <div>
                 <div className="tx-overview-graph-step-title">
                   {isAttestation ? "Token" : "Amount"}
@@ -138,6 +141,17 @@ const Overview = ({
                     "N/A"
                   )}
                 </div>
+              </div>
+            )}
+            {nftInfo && (
+              <div>
+                <div className="tx-overview-graph-step-title">Sent</div>
+                <div className="tx-overview-graph-step-description">{nftInfo.name}</div>
+                {nftInfo.image && (
+                  <a href={nftInfo.image} target="_blank" rel="noopener noreferrer">
+                    <img src={nftInfo.image} width={200} height={200} />
+                  </a>
+                )}
               </div>
             )}
             <div>
@@ -416,7 +430,7 @@ const Overview = ({
               </Tooltip>
             </div>
             <div className="tx-overview-graph-step-data-container">
-              {!isMayanOnly && (
+              {!isMayanOnly && !nftInfo && (
                 <div>
                   <div className="tx-overview-graph-step-title">
                     {isAttestation ? "Target Token" : "Redeem Amount"}

--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -285,6 +285,7 @@ const Information = ({ blockData, data, extraRawInfo, isRPC, setTxData }: Props)
     isGatewaySource,
     isMayanOnly: appIds?.length === 1 && appIds.includes(MAYAN_APP_ID),
     isUnknownApp,
+    nftInfo: payload.nftInfo || null,
     originDateParsed,
     parsedDestinationAddress,
     parsedEmitterAddress,


### PR DESCRIPTION
### Description

Adds initial support for Portal Bridge NFTs, with and without IPFS.

If the request fails, we try to fetch again with a CORS Proxy, that fixes 80% of the problems, but some URLs have anti-cors-proxies, so we'll need to move the calls to the BFF instead of doing them from the client.

Also, this PR adds support for image-type NFTs, so support for 3D/Video/Audio should be added.

### Screenshots

![Screenshot 2024-06-03 at 10 32 30](https://github.com/XLabs/wormscan-ui/assets/41705567/f917961b-8df9-4775-8371-a5418d739b79)

![Screenshot 2024-06-03 at 10 32 38](https://github.com/XLabs/wormscan-ui/assets/41705567/90767f67-bf12-434a-a3d2-385bdb5befe6)


