### PR TITLE
Add observations support

### DIFF
--- a/src/api/guardian-network/GuardianNetwork.ts
+++ b/src/api/guardian-network/GuardianNetwork.ts
@@ -149,6 +149,11 @@ export class GuardianNetwork {
     return payload || [];
   }
 
+  async getObservationForTxHash(txHash: string): Promise<Observation[]> {
+    const payload = await this._client.doGet<[]>(`/observations?txHash=${txHash}`);
+    return payload || [];
+  }
+
   private _vaaSearchCriteriaToPathSegmentFilter(
     prefix: string,
     criteria: {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -107,7 +107,13 @@ export const getGuardianSet = (version: number): GuardianSet[] => {
     name: "xLabs",
   };
 
-  const versions: Record<number, GuardianSet[]> = { 1: v1, 2: v2, 3: v3 };
+  const v4 = [...v3];
+  v4[1] = {
+    pubkey: "0x5893B5A76c3f739645648885bDCcC06cd70a3Cd3",
+    name: "RockawayX",
+  };
+
+  const versions: Record<number, GuardianSet[]> = { 1: v1, 2: v2, 3: v3, 4: v4 };
   return versions[version] || [];
 };
 

--- a/src/pages/Tx/Information/AdvancedView/index.tsx
+++ b/src/pages/Tx/Information/AdvancedView/index.tsx
@@ -104,7 +104,11 @@ const AdvancedView = ({
           <BlockSection title="PAYLOAD" code={payload && JSON.stringify(payload, null, 4)} />
 
           {!!extraRawInfo && (
-            <BlockSection code={JSON.stringify(extraRawInfo, null, 4)} title="Extra info" />
+            <BlockSection
+              id="signatures2"
+              code={JSON.stringify(extraRawInfo, null, 4)}
+              title="Extra info"
+            />
           )}
 
           {relayerInfo && (
@@ -220,7 +224,11 @@ const AdvancedView = ({
             </>
           )}
 
-          <BlockSection title="SIGNED VAA" code={signedVAA && JSON.stringify(signedVAA, null, 4)} />
+          <BlockSection
+            id="signatures"
+            title="SIGNED VAA"
+            code={signedVAA && JSON.stringify(signedVAA, null, 4)}
+          />
         </div>
       </div>
     </div>
@@ -244,7 +252,7 @@ const Button = ({
   </button>
 );
 
-const BlockSection = ({ title, code }: { title: string; code: any }) => {
+export const BlockSection = ({ title, code, id }: { title: string; code: any; id?: string }) => {
   if (!code) return null;
   const jsonParsed = JSON.parse(code);
 
@@ -268,7 +276,7 @@ const BlockSection = ({ title, code }: { title: string; code: any }) => {
   };
 
   return (
-    <div className="tx-advanced-view-container-block">
+    <div className="tx-advanced-view-container-block" id={id || title.replaceAll(" ", "")}>
       <div className="tx-advanced-view-container-block-top">
         <div className="tx-advanced-view-container-block-title">{title}</div>
         <div className="tx-advanced-view-container-block-copy">

--- a/src/pages/Tx/Information/Overview/index.tsx
+++ b/src/pages/Tx/Information/Overview/index.tsx
@@ -38,6 +38,7 @@ export type OverviewProps = {
     status?: string;
     refundStatus?: string;
   };
+  setShowOverview?: (bool: boolean) => void;
   showMetaMaskBtn?: boolean;
   showSignatures?: boolean;
   sourceSymbol?: string;
@@ -80,6 +81,7 @@ const Overview = ({
   parsedRedeemTx,
   redeemedAmount,
   relayerNTTStatus,
+  setShowOverview,
   showMetaMaskBtn,
   showSignatures,
   sourceSymbol,
@@ -282,7 +284,25 @@ const Overview = ({
             <div>
               <div className="tx-overview-graph-step-title">Signatures</div>
               <div className="tx-overview-graph-step-description">
-                {showSignatures ? `${guardianSignaturesCount} / ${totalGuardiansNeeded}` : "N/A"}
+                <a
+                  onClick={() => {
+                    setShowOverview(false);
+                    setTimeout(() => {
+                      const signedVaaElem = document.getElementById("signatures");
+                      if (signedVaaElem) {
+                        signedVaaElem.scrollIntoView({ behavior: "smooth", block: "start" });
+                      } else {
+                        const extraRawElem = document.getElementById("signatures2");
+                        if (extraRawElem) {
+                          extraRawElem.scrollIntoView({ behavior: "smooth", block: "start" });
+                        }
+                      }
+                    }, 100);
+                  }}
+                  style={{ cursor: "pointer" }}
+                >
+                  {showSignatures ? `${guardianSignaturesCount} / ${totalGuardiansNeeded}` : "N/A"}
+                </a>
               </div>
             </div>
 

--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -68,7 +68,9 @@ const Information = ({ blockData, data, extraRawInfo, isRPC, setTxData }: Props)
   const totalGuardiansNeeded = currentNetwork === "MAINNET" ? 13 : 1;
   const vaa = data?.vaa;
   const { isDuplicated } = data?.vaa || {};
-  const guardianSignaturesCount = data?.decodedVaa?.guardianSignatures?.length || 0;
+  const guardianSignaturesCount =
+    data?.decodedVaa?.guardianSignatures?.length || extraRawInfo?.signatures?.length || 0;
+
   const hasVAA = !!vaa;
 
   const { currentBlock, lastFinalizedBlock } = blockData || {};
@@ -293,6 +295,7 @@ const Information = ({ blockData, data, extraRawInfo, isRPC, setTxData }: Props)
     parsedPayload,
     parsedRedeemTx,
     redeemedAmount,
+    setShowOverview,
     showMetaMaskBtn,
     showSignatures: !(appIds && appIds.includes(CCTP_MANUAL_APP_ID)),
     sourceSymbol,

--- a/src/utils/fetchWithRPCsFallthrough.ts
+++ b/src/utils/fetchWithRPCsFallthrough.ts
@@ -171,8 +171,8 @@ export async function fetchWithRpcFallThrough(env: Environment, searchValue: str
             { pageSize: 20, page: 0, sortOrder: Order.ASC },
           );
 
-          if (!!observations.length) {
-            const guardianSetList = getGuardianSet(3);
+          if (!!observations?.length) {
+            const guardianSetList = getGuardianSet(4);
 
             const signedGuardians = observations.map(({ guardianAddr, signature }) => ({
               signature: Buffer.from(signature).toString(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4835,9 +4835,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001517":
-  version: 1.0.30001579
-  resolution: "caniuse-lite@npm:1.0.30001579"
-  checksum: 7539dcff74d2243a30c428393dc690c87fa34d7da36434731853e9bcfe783757763b2971f5cc878e25242a93e184e53f167d11bd74955af956579f7af71cc764
+  version: 1.0.30001636
+  resolution: "caniuse-lite@npm:1.0.30001636"
+  checksum: b0347fd2c8d346680a64d98b061c59cb8fbf149cdd03005a447fae4d21e6286d5bd161b43eefe3221c6624aacb3cda4e838ae83c95ff5313a547f84ca93bcc70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This PR adds support for cases where there's not a VAA yet but there are some observations to it. So instead of showing the user "we have no data" we can at least show the signatures we have and from what guardians they are.

---

### Screenshots

With RPC data (RPCs were able to get at least some of the tx information):

https://github.com/XLabs/wormscan-ui/assets/41705567/9a73a1b3-a303-40a5-8e86-e673e72fa635

-

With no data (nor API or RPC has any data for the txn):

![Screenshot 2024-06-18 at 11 57 12](https://github.com/XLabs/wormscan-ui/assets/41705567/fc0b3ddb-171b-4e56-a535-53702d596cc7)
