### PR TITLE
Improve observations handling

### DIFF
--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -497,8 +497,24 @@ const Tx = () => {
             hash: parsedHash,
             sequence: parsedSequence,
           };
-        }
+        } else {
+          if (!!txHash) {
+            const observations = await getClient().guardianNetwork.getObservationForTxHash(txHash);
 
+            if (!!observations?.length) {
+              const guardianSetList = getGuardianSet(4);
+
+              const signedGuardians = observations.map(({ guardianAddr, signature }) => ({
+                signature: Buffer.from(signature).toString(),
+                name: guardianSetList?.find(a => a.pubkey === guardianAddr)?.name,
+              }));
+
+              data.decodedVaa = {
+                guardianSignatures: signedGuardians,
+              };
+            }
+          }
+        }
         // ---
 
         // check CCTP
@@ -1345,6 +1361,7 @@ const Tx = () => {
       setAddressesInfo,
       setShowSourceTokenUrl,
       setShowTargetTokenUrl,
+      txHash,
     ],
   );
 
@@ -1397,7 +1414,11 @@ const Tx = () => {
             <br />
 
             <BlockSection
-              code={JSON.stringify(observationsOnlyData, null, 4)}
+              code={JSON.stringify(observationsOnlyData.signatures, null, 4)}
+              title="Signatures Data"
+            />
+            <BlockSection
+              code={JSON.stringify(observationsOnlyData.observations, null, 4)}
               title="Observations Data"
             />
           </>


### PR DESCRIPTION
### Description

This PR improves the observations handling:

- When the `/operations` endpoint has a response, but it doesn't have the `vaa` field (no vaa emitted yet), we call the observations endpoint to get the current signatures and we display the regular UI with the signatures and information.
- When the `/operations` endpoint has no response for a txHash, we call the observations endpoint and we show a only-data screen with the signatures, the observations, the txHash and the vaa-id.

### Screenshots

with operations without vaa
![Screenshot 2024-06-28 at 11 41 34](https://github.com/XLabs/wormscan-ui/assets/41705567/24858dfe-a6ce-4f61-a55f-83060eb208f7)

without operations
![Screenshot 2024-06-28 at 11 44 28](https://github.com/XLabs/wormscan-ui/assets/41705567/73973048-ca3a-40ff-bd1c-a54a393d94f7)

