### PR TITLE
Flipping numbers for some stats and front unification of portal and connect data

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-dom": "18.2.0",
     "react-draggable": "4.4.5",
     "react-dropzone": "^14.2.3",
+    "react-flip-numbers": "^3.0.8",
     "react-i18next": "12.1.5",
     "react-json-view-lite": "1.4.0",
     "react-lottie-player": "^2.1.0",

--- a/src/components/molecules/ProtocolsActivity/index.tsx
+++ b/src/components/molecules/ProtocolsActivity/index.tsx
@@ -221,7 +221,9 @@ const ProtocolsActivity = () => {
             className="protocols-activity-container-top-select-protocol"
             controlStyles={{ minWidth: 256 }}
             isMulti={false}
-            items={PROTOCOL_LIST.filter(protocol => protocol.value !== PORTAL_NFT_APP_ID)}
+            items={PROTOCOL_LIST.filter(
+              protocol => protocol.value !== PORTAL_NFT_APP_ID && protocol.value !== "CONNECT",
+            )}
             menuListStyles={{ maxHeight: isDesktop ? 264 : 180 }}
             menuPortalStyles={{ zIndex: 100 }}
             name="protocol"

--- a/src/components/molecules/WormholeStats/index.tsx
+++ b/src/components/molecules/WormholeStats/index.tsx
@@ -1,4 +1,6 @@
-import { useState } from "react";
+import WormholeLogo from "src/assets/wormhole-stats.svg";
+import FlipNumbers from "react-flip-numbers";
+import { CSSProperties, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "react-query";
 import { useEnvironment } from "src/context/EnvironmentContext";
@@ -8,7 +10,6 @@ import { ErrorPlaceholder } from "src/components/molecules";
 import { formatNumber } from "src/utils/number";
 import { getClient } from "src/api/Client";
 import { InfoCircleIcon, LinkIcon } from "src/icons/generic";
-import WormholeLogo from "src/assets/wormhole-stats.svg";
 import "./styles.scss";
 
 const RANGE_LIST: { label: string; value: "24h" | "7d" | "30d" }[] = [
@@ -27,7 +28,9 @@ const WormholeStats = () => {
     isLoading,
     isError,
     data: scoreData,
-  } = useQuery("scoresResponse", () => getClient().guardianNetwork.getScores());
+  } = useQuery("scoresResponse", () => getClient().guardianNetwork.getScores(), {
+    refetchInterval: 25000,
+  });
 
   const {
     "24h_messages": messages24h,
@@ -66,7 +69,23 @@ const WormholeStats = () => {
               </Tooltip>
             </div>
             <div className="wormhole-stats-container-item-value">
-              {total_messages ? formatNumber(Number(total_messages), 0) : "-"}
+              <div className="wormhole-stats-container-item-value-flip">
+                {total_messages ? (
+                  <FlipNumbers
+                    height={20}
+                    width={14}
+                    color="white"
+                    background="var(--color-gray-900)"
+                    play
+                    perspective={100}
+                    numbers={formatNumber(Number(total_messages), 0)}
+                    numberStyle={flipNumberCSS}
+                    nonNumberStyle={{ ...flipNumberCSS, fontSize: 20 }}
+                  />
+                ) : (
+                  "-"
+                )}
+              </div>
             </div>
           </div>
 
@@ -86,7 +105,23 @@ const WormholeStats = () => {
               </Tooltip>
             </div>
             <div className="wormhole-stats-container-item-value">
-              {messages24h ? formatNumber(Number(messages24h), 0) : "-"}
+              <div className="wormhole-stats-container-item-value-flip">
+                {messages24h ? (
+                  <FlipNumbers
+                    height={20}
+                    width={14}
+                    color="white"
+                    background="var(--color-gray-900)"
+                    play
+                    perspective={100}
+                    numbers={formatNumber(Number(messages24h), 0)}
+                    numberStyle={flipNumberCSS}
+                    nonNumberStyle={{ ...flipNumberCSS, fontSize: 20 }}
+                  />
+                ) : (
+                  "-"
+                )}
+              </div>
             </div>
           </div>
 
@@ -105,7 +140,24 @@ const WormholeStats = () => {
               </Tooltip>
             </div>
             <div className="wormhole-stats-container-item-value">
-              {isMainnet ? <>${total_volume ? formatNumber(Number(total_volume)) : "-"}</> : "-"}
+              {isMainnet ? (
+                <div className="wormhole-stats-container-item-value-flip">
+                  <span className="wormhole-stats-container-item-value-flip-dollar">$</span>
+                  <FlipNumbers
+                    height={20}
+                    width={14}
+                    color="white"
+                    background="var(--color-gray-900)"
+                    play
+                    perspective={100}
+                    numbers={formatNumber(Number(total_volume), 0)}
+                    numberStyle={flipNumberCSS}
+                    nonNumberStyle={{ ...flipNumberCSS, fontSize: 20 }}
+                  />
+                </div>
+              ) : (
+                "-"
+              )}
             </div>
           </div>
 
@@ -165,7 +217,24 @@ const WormholeStats = () => {
             </div>
             <div className="wormhole-stats-container-item-value">
               {isMainnet ? (
-                <>${selectedVolume ? formatNumber(Number(selectedVolume), 0) : "-"}</>
+                <div className="wormhole-stats-container-item-value-flip">
+                  <span className="wormhole-stats-container-item-value-flip-dollar">$</span>
+                  {selectedVolume ? (
+                    <FlipNumbers
+                      height={20}
+                      width={14}
+                      color="white"
+                      background="var(--color-gray-900)"
+                      play
+                      perspective={100}
+                      numbers={formatNumber(Number(selectedVolume), 0)}
+                      numberStyle={flipNumberCSS}
+                      nonNumberStyle={{ ...flipNumberCSS, fontSize: 20 }}
+                    />
+                  ) : (
+                    "-"
+                  )}
+                </div>
               ) : (
                 "-"
               )}
@@ -192,6 +261,13 @@ const WormholeStats = () => {
       )}
     </div>
   );
+};
+
+const flipNumberCSS: CSSProperties = {
+  fontFamily: "Roboto Mono",
+  fontSize: "18px",
+  fontWeight: 400,
+  letterSpacing: "0px",
 };
 
 export default WormholeStats;

--- a/src/components/molecules/WormholeStats/styles.scss
+++ b/src/components/molecules/WormholeStats/styles.scss
@@ -23,7 +23,8 @@
 
   &-container {
     display: grid;
-    gap: 36px;
+    row-gap: 36px;
+    column-gap: 20px;
     grid-template-columns: repeat(2, 1fr);
     padding-bottom: 40px;
     position: relative;
@@ -102,8 +103,29 @@
       }
 
       &-value {
+        display: flex;
+
         @include text-heading4;
         color: var(--color-white);
+
+        &-flip {
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          gap: 3px;
+          margin-top: 2px;
+
+          transform: scale(0.8) translateX(-12%);
+          width: 180px;
+          @media only screen and (min-width: 520px) {
+            transform: none;
+            width: auto;
+          }
+
+          &-dollar {
+            transform: translateY(1px);
+          }
+        }
 
         &-link {
           @include centered-row;

--- a/src/pages/Analytics/WToken/Summary.tsx
+++ b/src/pages/Analytics/WToken/Summary.tsx
@@ -1,3 +1,4 @@
+import FlipNumbers from "react-flip-numbers";
 import { BlockchainIcon } from "src/components/atoms";
 import { WORMHOLE_PAGE_URL } from "src/consts";
 import { useEnvironment } from "src/context/EnvironmentContext";
@@ -71,10 +72,36 @@ export const Summary = ({
 
             <div className="summary-top-content-container-item">
               <div className="summary-top-content-container-item-up">Price</div>
-              <div className="summary-top-content-container-item-down">
-                {isFetchingWTokenPrice || isErrorWTokenPrice
-                  ? "..."
-                  : `$${formatNumber(+wTokenPrice, 3)}`}
+              <div className="summary-top-content-container-item-down price">
+                <div className="price-value">
+                  {isFetchingWTokenPrice || (isErrorWTokenPrice && "...")}
+
+                  {wTokenPrice && (
+                    <FlipNumbers
+                      height={15}
+                      width={11}
+                      color="white"
+                      background="var(--color-gray-900)"
+                      play
+                      perspective={100}
+                      numbers={`$${formatNumber(+wTokenPrice, 4)}`}
+                      numberStyle={{
+                        fontFamily: "Roboto",
+                        fontSize: "14px",
+                        fontWeight: 400,
+                        letterSpacing: "0.02em",
+                        lineHeight: "20px",
+                      }}
+                      nonNumberStyle={{
+                        fontFamily: "Roboto",
+                        fontSize: "14px",
+                        fontWeight: 400,
+                        letterSpacing: "0.02em",
+                        lineHeight: "20px",
+                      }}
+                    />
+                  )}
+                </div>
               </div>
             </div>
 

--- a/src/pages/Analytics/WToken/index.tsx
+++ b/src/pages/Analytics/WToken/index.tsx
@@ -77,14 +77,20 @@ const WToken = () => {
     data: wTokenPrice,
     isError: isErrorWTokenPrice,
     isFetching: isFetchingWTokenPrice,
-  } = useQuery(["getWTokenInfo"], async () => {
-    const data = await getGeckoTokenInfo(
-      "85VBFQZC9TZkfaptBWjvUw7YbZjy52A6mjtPGjstQAmQ",
-      chainToChainId("Solana"),
-    );
-    if (!data || !data.attributes?.price_usd) return null;
-    return data.attributes.price_usd;
-  });
+  } = useQuery(
+    ["getWTokenInfo"],
+    async () => {
+      const data = await getGeckoTokenInfo(
+        "85VBFQZC9TZkfaptBWjvUw7YbZjy52A6mjtPGjstQAmQ",
+        chainToChainId("Solana"),
+      );
+      if (!data || !data.attributes?.price_usd) return null;
+      return data.attributes.price_usd;
+    },
+    {
+      refetchInterval: 10000,
+    },
+  );
 
   const {
     data: transfersByTime,

--- a/src/pages/Analytics/WToken/styles.scss
+++ b/src/pages/Analytics/WToken/styles.scss
@@ -130,7 +130,16 @@
             padding: 12px;
             @include text-roboto-body-400;
             font-size: 16px;
-            max-height: 44px;
+            height: 44px;
+
+            &.price {
+              position: relative;
+
+              .price-value {
+                position: absolute;
+                top: 30%;
+              }
+            }
 
             &.community {
               @include centered-row;

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -10,6 +10,7 @@ import {
   CCTP_MANUAL_APP_ID,
   GATEWAY_APP_ID,
   GR_APP_ID,
+  PORTAL_APP_ID,
   USDT_TRANSFER_APP_ID,
 } from "src/consts";
 
@@ -88,6 +89,10 @@ export const parseTx = ({ value, chainId }: { value: string; chainId: ChainId })
 };
 
 export const formatAppId = (appId: string) => {
+  if (appId === PORTAL_APP_ID) {
+    return "Portal";
+  }
+
   if (appId === GR_APP_ID) {
     return "Standard Relayer";
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8997,6 +8997,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-flip-numbers@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "react-flip-numbers@npm:3.0.8"
+  dependencies:
+    react-simple-animate: ^3.0.1
+  peerDependencies:
+    react: ^16.8.0 || ^17 || ^18
+    react-dom: ^16.8.0 || ^17 || ^18
+    react-simple-animate: ^3.0.1
+  checksum: ff355565d22aa5dee6d6ed0ca33d49ee5d7ef811542b6b0efd0749e92ab880935712dfb60a2d9f56dffffcc7312cb2416b16d3b68ae47f7c2dd5ff9cabd1db75
+  languageName: node
+  linkType: hard
+
 "react-i18next@npm:12.1.5":
   version: 12.1.5
   resolution: "react-i18next@npm:12.1.5"
@@ -9120,6 +9133,15 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 1cb03c308be98b0bb89361dd842b92010ebd6769e388c380f2303ccfb14768b2085d0b94478dcd67841991272570fd27f75ea3035a230378fe14215d857e8ff7
+  languageName: node
+  linkType: hard
+
+"react-simple-animate@npm:^3.0.1":
+  version: 3.5.2
+  resolution: "react-simple-animate@npm:3.5.2"
+  peerDependencies:
+    react-dom: ^16.8.0 || ^17 || ^18
+  checksum: 9e892e95d5d0852384587a5aa6b9c2afade7f4796935f7f79cdb20f1649c909d3d8cea83c5a7784a5a6f78c0ab189bd7e786007f6b5d8bdab14685bd78767ed6
   languageName: node
   linkType: hard
 
@@ -10642,6 +10664,7 @@ __metadata:
     react-dom: 18.2.0
     react-draggable: 4.4.5
     react-dropzone: ^14.2.3
+    react-flip-numbers: ^3.0.8
     react-i18next: 12.1.5
     react-json-view-lite: 1.4.0
     react-lottie-player: ^2.1.0


### PR DESCRIPTION
### Description

- This PR unifies the Portal Token Bridge and Connect data for protocol stats (both in home for "Top 5 Protocols" and in "Protocol Stats" section) and also for Protocols Activity graph.

- Also, it adds "Flip Numbers" to the W Token price along with the home Wormhole stats. (currently kinda useless as those have caches and flip numbers won't be seen, only at first load ⚠️)

### Screenshots

BEFORE - AFTER [1]

![bef 1](https://github.com/user-attachments/assets/d93d8ee2-e42d-42e2-97a2-0b7f2ea70f48)
![aft 1](https://github.com/user-attachments/assets/ee211512-3b54-48c3-b404-722e6863a88e)

BEFORE - AFTER [2]

![bef 2](https://github.com/user-attachments/assets/df7b1be5-a209-4772-abd5-a32f2b19b273)
![aft 2](https://github.com/user-attachments/assets/6263e8ba-f6ac-4e70-8435-85a0f4dff30e)

FLIP NUMBERS


https://github.com/user-attachments/assets/64be9d78-29a7-459e-90c7-f9c52f28ac3e


