### PR TITLE
Better labels. Mayan protocol stats fixed.

### DIFF
--- a/src/api/guardian-network/GuardianNetwork.ts
+++ b/src/api/guardian-network/GuardianNetwork.ts
@@ -19,6 +19,7 @@ import {
   IChainActivityInput,
   IMayanActivity,
   IMayanActivityInput,
+  IMayanStats,
   IProtocolActivity,
   IProtocolActivityInput,
   LastTxs,
@@ -207,6 +208,7 @@ export class GuardianNetwork {
     return await this._client.doGet<ProtocolsStatsOutput[]>("/protocols/stats");
   }
 
+  // unused until this Mayan endpoint has the correct data
   async getMayanActivity({ from, to }: IMayanActivityInput): Promise<IMayanActivity> {
     const mayanResp = await fetch(
       `https://explorer-api.mayan.finance/v3/stats/wh/activity?from=${from}&to=${to}`,
@@ -216,6 +218,17 @@ export class GuardianNetwork {
       const mayanResponse = await mayanResp.json();
       return mayanResponse;
     }
+    return null;
+  }
+
+  async getMayanStats(): Promise<IMayanStats> {
+    const mayanResp = await fetch("https://explorer-api.mayan.finance/v3/stats/overview");
+
+    if (mayanResp.ok) {
+      const mayanResponse = await mayanResp.json();
+      return mayanResponse;
+    }
+
     return null;
   }
 

--- a/src/api/guardian-network/types.ts
+++ b/src/api/guardian-network/types.ts
@@ -139,6 +139,23 @@ export interface IMayanActivity {
   volume: number;
 }
 
+export interface IMayanStats {
+  last24h: {
+    volume: number;
+    toSolCount: number;
+    fromSolCount: number;
+    swaps: number;
+    activeTraders: number;
+  };
+  allTime: {
+    volume: number;
+    toSolCount: number;
+    fromSolCount: number;
+    swaps: number;
+    activeTraders: number;
+  };
+}
+
 export interface IAllbridgeActivityInput {
   from: string;
   to: string;

--- a/src/components/molecules/ProtocolsStats/index.tsx
+++ b/src/components/molecules/ProtocolsStats/index.tsx
@@ -22,11 +22,11 @@ import "./styles.scss";
 interface ITable {
   protocol: string;
   total_value_transferred: number;
-  two_days_ago_value_transferred: number;
+  two_days_ago_value_transferred: number | string;
   last_day_value_transferred: number;
   last_day_value_diff_percentage: string;
   total_messages: number;
-  two_days_ago_messages: number;
+  two_days_ago_messages: number | string;
   last_day_messages: number;
   last_day_diff_percentage: string;
 }
@@ -61,13 +61,14 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
   const [dataTable, setDataTable] = useState<ITable[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  const { data: monthlyData, isError: isErrorMonthly } = useQuery(["monthlyData"], () =>
+  const { data: allData, isError: isErrorAllData } = useQuery(["allData"], () =>
     getClient().guardianNetwork.getProtocolActivity({
       from: firstDataAvailableDate,
       to: todayISOString,
       timespan: "1mo",
     }),
   );
+
   const { data: last48To24HoursData, isError: isError48To24 } = useQuery(
     ["last48To24HoursData"],
     () =>
@@ -77,6 +78,7 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
         timespan: "1h",
       }),
   );
+
   const { data: last24HoursData, isError: isError24Hours } = useQuery(["last24HoursData"], () =>
     getClient().guardianNetwork.getProtocolActivity({
       from: oneDayAgoISOString,
@@ -94,6 +96,7 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
       }),
     { enabled: isMainnet },
   );
+
   const { data: last48To24HoursAllbridge, isError: isErrorLast48To24Allbridge } = useQuery(
     ["last48To24HoursAllbridge"],
     () =>
@@ -103,6 +106,7 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
       }),
     { enabled: isMainnet },
   );
+
   const { data: last24HoursAllbridge, isError: isErrorLast24HoursAllbridge } = useQuery(
     ["last24HoursAllbridge"],
     () =>
@@ -118,35 +122,42 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
     () => getClient().guardianNetwork.getProtocolsStats(),
     { enabled: isMainnet },
   );
-  const { data: last48To24HoursMayan, isError: isErrorLast48To24Mayan } = useQuery(
-    ["last48To24HoursMayan"],
-    () =>
-      getClient().guardianNetwork.getMayanActivity({
-        from: twoDaysAgoISOString,
-        to: oneDayAgoISOString,
-      }),
-    { enabled: isMainnet },
-  );
-  const { data: last24HoursMayan, isError: isErrorLast24HoursMayan } = useQuery(
-    ["last24HoursMayan"],
-    () =>
-      getClient().guardianNetwork.getMayanActivity({
-        from: oneDayAgoISOString,
-        to: todayISOString,
-      }),
+
+  const { data: mayanStats, isError: isErrorMayanStats } = useQuery(
+    ["mayanStats"],
+    () => getClient().guardianNetwork.getMayanStats(),
     { enabled: isMainnet },
   );
 
+  // const { data: last48To24HoursMayan, isError: isErrorLast48To24Mayan } = useQuery(
+  //   ["last48To24HoursMayan"],
+  //   () =>
+  //     getClient().guardianNetwork.getMayanActivity({
+  //       from: twoDaysAgoISOString,
+  //       to: oneDayAgoISOString,
+  //     }),
+  //   { enabled: isMainnet },
+  // );
+
+  // const { data: last24HoursMayan, isError: isErrorLast24HoursMayan } = useQuery(
+  //   ["last24HoursMayan"],
+  //   () =>
+  //     getClient().guardianNetwork.getMayanActivity({
+  //       from: oneDayAgoISOString,
+  //       to: todayISOString,
+  //     }),
+  //   { enabled: isMainnet },
+  // );
+
   const isError =
-    isErrorMonthly ||
+    isErrorAllData ||
     isError48To24 ||
     isError24Hours ||
     isErrorAllTimeAllbridge ||
     isErrorLast48To24Allbridge ||
     isErrorLast24HoursAllbridge ||
     isErrorStats ||
-    isErrorLast48To24Mayan ||
-    isErrorLast24HoursMayan;
+    isErrorMayanStats;
 
   useEffect(() => {
     setIsLoading(true);
@@ -156,20 +167,19 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
 
     if (
       (isMainnet &&
-        monthlyData &&
+        allData &&
         last48To24HoursData &&
         last24HoursData &&
         allTimeAllbridge &&
         last48To24HoursAllbridge &&
         last24HoursAllbridge &&
         stats &&
-        last48To24HoursMayan &&
-        last24HoursMayan) ||
-      (!isMainnet && monthlyData && last48To24HoursData && last24HoursData)
+        mayanStats) ||
+      (!isMainnet && allData && last48To24HoursData && last24HoursData)
     ) {
       const processedData: ITable[] = [];
 
-      monthlyData
+      allData
         .filter(
           item =>
             item.app_id !== "STABLE" &&
@@ -287,28 +297,28 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
 
         processedData.push(allbridgeData);
 
-        const mayanInfo = stats.find(item => item.protocol === "mayan");
+        // const mayanInfo = stats.find(item => item.protocol === "mayan");
 
-        const mayanLastDayValueDiffPercentage = calculatePercentageDiff(
-          last24HoursMayan.total_value_transferred,
-          last48To24HoursMayan.total_value_transferred,
-        );
+        // const mayanLastDayValueDiffPercentage = calculatePercentageDiff(
+        //   last24HoursMayan.total_value_transferred,
+        //   last48To24HoursMayan.total_value_transferred,
+        // );
 
-        const mayanLastDayMessagesDiffPercentage = calculatePercentageDiff(
-          last24HoursMayan.total_messages,
-          last48To24HoursMayan.total_messages,
-        );
+        // const mayanLastDayMessagesDiffPercentage = calculatePercentageDiff(
+        //   last24HoursMayan.total_messages,
+        //   last48To24HoursMayan.total_messages,
+        // );
 
         const mayanData = {
           protocol: MAYAN_APP_ID,
-          total_value_transferred: mayanInfo.total_value_transferred,
-          total_messages: mayanInfo.total_messages,
-          two_days_ago_value_transferred: last48To24HoursMayan.total_value_transferred,
-          last_day_value_transferred: last24HoursMayan.total_value_transferred,
-          last_day_value_diff_percentage: mayanLastDayValueDiffPercentage,
-          two_days_ago_messages: last48To24HoursMayan.total_messages,
-          last_day_messages: last24HoursMayan.total_messages,
-          last_day_diff_percentage: mayanLastDayMessagesDiffPercentage,
+          total_value_transferred: mayanStats.allTime.volume,
+          total_messages: mayanStats.allTime.swaps,
+          two_days_ago_value_transferred: "N/A",
+          last_day_value_transferred: mayanStats.last24h.volume,
+          last_day_value_diff_percentage: "N/A",
+          two_days_ago_messages: "N/A",
+          last_day_messages: mayanStats.last24h.swaps,
+          last_day_diff_percentage: "N/A",
         };
 
         processedData.push(mayanData);
@@ -323,17 +333,16 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
       }
     }
   }, [
-    monthlyData,
+    allData,
     last48To24HoursData,
     last24HoursData,
     allTimeAllbridge,
     last48To24HoursAllbridge,
     last24HoursAllbridge,
     stats,
-    last48To24HoursMayan,
-    last24HoursMayan,
     isMainnet,
     isError,
+    mayanStats,
   ]);
 
   return (
@@ -387,6 +396,7 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
               const { diffClass: diffValueClass, prefix: prefixValue } = getClassAndPrefix(
                 last_day_value_diff_percentage,
               );
+
               const { diffClass: diffMessagesClass, prefix: prefixMessages } =
                 getClassAndPrefix(last_day_diff_percentage);
 
@@ -425,29 +435,31 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
                         <h4 className="protocols-stats-container-element-item-title">24H VOLUME</h4>
                         <p className="protocols-stats-container-element-item-value">
                           ${formatNumber(item?.last_day_value_transferred, 0)}
-                          <Tooltip
-                            type="info"
-                            tooltip={
-                              <div className="protocols-stats-container-element-item-value-tooltipasd">
-                                <p>
-                                  ${formatNumber(item?.two_days_ago_value_transferred, 0)} were
-                                  transferred in the previous 24 hours.
-                                </p>
-                                <br />
-                                <p>
-                                  ${formatNumber(item?.last_day_value_transferred, 0)} were
-                                  transferred in the last 24 hours.
-                                </p>
-                              </div>
-                            }
-                          >
-                            <span
-                              className={`protocols-stats-container-element-item-value-diff ${diffValueClass}`}
+                          {item?.two_days_ago_value_transferred !== "N/A" && (
+                            <Tooltip
+                              type="info"
+                              tooltip={
+                                <div className="protocols-stats-container-element-item-value-tooltip">
+                                  <p>
+                                    ${formatNumber(+item?.two_days_ago_value_transferred, 0)} were
+                                    transferred in the previous 24 hours.
+                                  </p>
+                                  <br />
+                                  <p>
+                                    ${formatNumber(item?.last_day_value_transferred, 0)} were
+                                    transferred in the last 24 hours.
+                                  </p>
+                                </div>
+                              }
                             >
-                              {prefixValue}
-                              {last_day_value_diff_percentage}
-                            </span>
-                          </Tooltip>
+                              <span
+                                className={`protocols-stats-container-element-item-value-diff ${diffValueClass}`}
+                              >
+                                {prefixValue}
+                                {last_day_value_diff_percentage}
+                              </span>
+                            </Tooltip>
+                          )}
                         </p>
                       </div>
                     </>
@@ -466,29 +478,31 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
                     <h4 className="protocols-stats-container-element-item-title">24H TRANSFERS</h4>
                     <p className="protocols-stats-container-element-item-value">
                       {formatNumber(item?.last_day_messages, 0)}
-                      <Tooltip
-                        type="info"
-                        tooltip={
-                          <div className="protocols-stats-container-element-item-value-tooltipasd">
-                            <p>
-                              {formatNumber(item?.two_days_ago_messages, 0)} messages were sent in
-                              the previous 24 hours.
-                            </p>
-                            <br />
-                            <p>
-                              {formatNumber(item?.last_day_messages, 0)} messages were sent in the
-                              last 24 hours.
-                            </p>
-                          </div>
-                        }
-                      >
-                        <span
-                          className={`protocols-stats-container-element-item-value-diff ${diffMessagesClass}`}
+                      {item?.two_days_ago_messages !== "N/A" && (
+                        <Tooltip
+                          type="info"
+                          tooltip={
+                            <div className="protocols-stats-container-element-item-value-tooltipasd">
+                              <p>
+                                {formatNumber(+item?.two_days_ago_messages, 0)} messages were sent
+                                in the previous 24 hours.
+                              </p>
+                              <br />
+                              <p>
+                                {formatNumber(item?.last_day_messages, 0)} messages were sent in the
+                                last 24 hours.
+                              </p>
+                            </div>
+                          }
                         >
-                          {prefixMessages}
-                          {last_day_diff_percentage}
-                        </span>
-                      </Tooltip>
+                          <span
+                            className={`protocols-stats-container-element-item-value-diff ${diffMessagesClass}`}
+                          >
+                            {prefixMessages}
+                            {last_day_diff_percentage}
+                          </span>
+                        </Tooltip>
+                      )}
                     </p>
                   </div>
 

--- a/src/components/organisms/ChainActivity/index.tsx
+++ b/src/components/organisms/ChainActivity/index.tsx
@@ -43,8 +43,8 @@ const TYPE_CHART_LIST = [
 ];
 
 const METRIC_CHART_LIST = [
-  { label: "Volume", value: "volume", ariaLabel: "Volume" },
-  { label: "Transactions", value: "transactions", ariaLabel: "Transactions" },
+  { label: "Volumen", value: "volume", ariaLabel: "Volume" },
+  { label: "Transfers", value: "transactions", ariaLabel: "Transfers" },
 ];
 
 const ChainActivity = () => {
@@ -739,7 +739,20 @@ const ChainActivity = () => {
 
                 {metricSelected === "transactions" ? (
                   <div className="chain-activity-chart-top-filters-legends-container-total">
-                    <span>Transfers: </span>
+                    <span>
+                      {lastBtnSelected === "24h"
+                        ? "Daily"
+                        : lastBtnSelected === "week"
+                        ? "Weekly"
+                        : lastBtnSelected === "month"
+                        ? "Monthly"
+                        : lastBtnSelected === "year"
+                        ? "Yearly"
+                        : lastBtnSelected === "custom"
+                        ? ""
+                        : "All Time"}{" "}
+                      Total Transfers:{" "}
+                    </span>
                     <p>
                       {showAllSourceChains
                         ? formatNumber(allMessagesNumber, 0)
@@ -748,7 +761,20 @@ const ChainActivity = () => {
                   </div>
                 ) : (
                   <div className="chain-activity-chart-top-filters-legends-container-total">
-                    <span>Volume: </span>
+                    <span>
+                      {lastBtnSelected === "24h"
+                        ? "Daily"
+                        : lastBtnSelected === "week"
+                        ? "Weekly"
+                        : lastBtnSelected === "month"
+                        ? "Monthly"
+                        : lastBtnSelected === "year"
+                        ? "Yearly"
+                        : lastBtnSelected === "custom"
+                        ? ""
+                        : "All Time"}{" "}
+                      Total Volume:{" "}
+                    </span>
                     <p>
                       $
                       {showAllSourceChains
@@ -971,8 +997,8 @@ const ChainActivity = () => {
                     
                         ${
                           metricSelected === "transactions"
-                            ? `Total Transfers: <span>${formatNumber(totalY, 0)}</span>`
-                            : `Total Volume: <span>$${numberToSuffix(totalY)}</span>`
+                            ? `Transfers Sum: <span>${formatNumber(totalY, 0)}</span>`
+                            : `Volume Sum: <span>$${numberToSuffix(totalY)}</span>`
                         }
                       </div>
                       <p class="chain-activity-chart-tooltip-chains">Chains:</p>

--- a/src/components/organisms/ChainActivity/styles.scss
+++ b/src/components/organisms/ChainActivity/styles.scss
@@ -331,6 +331,7 @@
             gap: 8px;
 
             & .hidden-desktop-1150 {
+              margin-left: -4px;
               @include desktop {
                 @media screen and (max-width: 1150px) {
                   display: none;

--- a/src/components/organisms/TokenActivity/Chart.tsx
+++ b/src/components/organisms/TokenActivity/Chart.tsx
@@ -103,7 +103,7 @@ export const Chart = ({ data, filters, isError, isLoading, metricSelected }: Pro
               width="100%"
               series={[
                 {
-                  name: "Volume or Transactions",
+                  name: "Volume or Transfers",
                   color: "#7BFFB0",
                   data: dataTransformed
                     ? metricSelected === "volume"

--- a/src/components/organisms/TokenActivity/index.tsx
+++ b/src/components/organisms/TokenActivity/index.tsx
@@ -18,7 +18,7 @@ import "./styles.scss";
 
 const METRIC_CHART_LIST = [
   { label: "Volume", value: "volume", ariaLabel: "Volume" },
-  { label: "Transactions", value: "transactions", ariaLabel: "Transactions" },
+  { label: "Transfers", value: "transactions", ariaLabel: "Transfers" },
 ];
 
 const RANGE_LIST = [
@@ -260,7 +260,7 @@ const TokenActivity = ({ isHomePage = false }: { isHomePage?: boolean }) => {
           </div>
 
           <ToggleGroup
-            ariaLabel="Select metric type (volume or transactions)"
+            ariaLabel="Select metric type (volume or transfers)"
             className="token-activity-container-top-toggle"
             items={METRIC_CHART_LIST}
             onValueChange={value => setMetricSelected(value)}

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -51,7 +51,7 @@ export default {
           title: "Cross-Chain Activity",
           download: "Download",
           volume: "Volume",
-          count: "Transactions",
+          count: "Transfers",
           app: "App",
           source: "Source",
           destination: "Target",


### PR DESCRIPTION
### Description

This PR:

- Replaces the word `Transactions` for `Transfers` in a lot of places (cross-chain chart, chain activity chart, etc)
- Changes the Mayan endpoint used to get the info for Protocol Stats (with the new endpoint, we cannot show percentage of change for 24H volume/transfers, so Mayan wont show it)
- Changes the labels for Chains Activity chart 


