### PR TITLE
Add release time for IN GOVERNORS transactions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
         "@typescript-eslint/no-unused-vars": "off",
         "react-hooks/exhaustive-deps": "warn",
         "@typescript-eslint/no-non-null-assertion": "off",
-        "no-unsafe-optional-chaining": "off"
+        "no-unsafe-optional-chaining": "off",
+        "@typescript-eslint/no-unused-expressions": "off"
     }
 }

--- a/src/api/guardian-network/types.ts
+++ b/src/api/guardian-network/types.ts
@@ -437,5 +437,6 @@ export interface GetOperationsOutput {
   isDailyLimitExceeded?: boolean;
   transactionLimit?: number;
   relayerInfo?: DeliveryLifecycleRecord;
+  releaseTimestamp?: Date;
 }
 [];

--- a/src/pages/Tx/Information/Overview/index.tsx
+++ b/src/pages/Tx/Information/Overview/index.tsx
@@ -96,15 +96,16 @@ const Overview = ({
   redeemedAmount,
   refundStatus,
   refundText,
+  releaseTimestamp,
   resultLog,
   setShowOverview,
   showMetaMaskBtn,
   showSignatures,
   sourceAddress,
   sourceFee,
-  sourceTokenChain,
   sourceFeeUSD,
   sourceSymbol,
+  sourceTokenChain,
   sourceTokenInfo,
   sourceTokenLink,
   STATUS,
@@ -156,6 +157,15 @@ const Overview = ({
       window.removeEventListener("resize", updateWidth);
     };
   }, [lineValueWidth]);
+
+  const releaseDate = releaseTimestamp ? new Date(releaseTimestamp) : null;
+  const currentDate = new Date();
+  const diffInMilliseconds = releaseDate?.getTime() - currentDate.getTime();
+  const diffInHours = Math.floor(diffInMilliseconds / (1000 * 60 * 60));
+  const diffInMinutes = Math.floor((diffInMilliseconds % (1000 * 60 * 60)) / (1000 * 60));
+  const remainingTime = `${diffInHours <= 0 ? "" : `${diffInHours}h, `}${
+    diffInMinutes <= 0 ? "" : `${diffInMinutes}m`
+  } left`;
 
   return (
     <div className="tx-overview">
@@ -452,6 +462,28 @@ const Overview = ({
           <div className="tx-overview-section-row-info">
             <div className="tx-overview-section-row-info-container">
               <div className="text">{originDateParsed ? originDateParsed : "N/A"}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="tx-overview-section-row">
+          <h4 className="tx-overview-section-row-title">
+            <Tooltip
+              type="info"
+              tooltip={
+                <div>
+                  <p>The date and time when the transaction will get released by the Governors.</p>
+                </div>
+              }
+            >
+              <span>
+                <InfoCircleIcon /> Release Time
+              </span>
+            </Tooltip>
+          </h4>
+          <div className="tx-overview-section-row-info">
+            <div className="tx-overview-section-row-info-container">
+              <div className="text">{releaseTimestamp ? `${remainingTime}` : "N/A"}</div>
             </div>
           </div>
         </div>

--- a/src/pages/Tx/Information/Overview/index.tsx
+++ b/src/pages/Tx/Information/Overview/index.tsx
@@ -466,27 +466,31 @@ const Overview = ({
           </div>
         </div>
 
-        <div className="tx-overview-section-row">
-          <h4 className="tx-overview-section-row-title">
-            <Tooltip
-              type="info"
-              tooltip={
-                <div>
-                  <p>The date and time when the transaction will get released by the Governors.</p>
-                </div>
-              }
-            >
-              <span>
-                <InfoCircleIcon /> Release Time
-              </span>
-            </Tooltip>
-          </h4>
-          <div className="tx-overview-section-row-info">
-            <div className="tx-overview-section-row-info-container">
-              <div className="text">{releaseTimestamp ? `${remainingTime}` : "N/A"}</div>
+        {releaseTimestamp && (
+          <div className="tx-overview-section-row">
+            <h4 className="tx-overview-section-row-title">
+              <Tooltip
+                type="info"
+                tooltip={
+                  <div>
+                    <p>
+                      The date and time when the transaction will get released by the Governors.
+                    </p>
+                  </div>
+                }
+              >
+                <span>
+                  <InfoCircleIcon /> Release Time
+                </span>
+              </Tooltip>
+            </h4>
+            <div className="tx-overview-section-row-info">
+              <div className="tx-overview-section-row-info-container">
+                <div className="text">{releaseTimestamp ? `${remainingTime}` : "N/A"}</div>
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
         {destinationDateParsed && (
           <div className="tx-overview-section-row">

--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -440,6 +440,7 @@ const Information = ({
     parsedRedeemTx,
     payloadType,
     redeemedAmount,
+    releaseTimestamp: data?.releaseTimestamp,
     setShowOverview,
     showMetaMaskBtn,
     showSignatures: !(appIds && appIds.includes(CCTP_MANUAL_APP_ID)),

--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -1253,6 +1253,20 @@ const Tx = () => {
         data.isDailyLimitExceeded = isDailyLimitExceeded;
         data.transactionLimit = transactionLimit;
 
+        if (STATUS === "IN_GOVERNORS") {
+          const enqueuedTransactions = await getClient(
+            environment.network,
+          ).governor.getEnqueuedTransactions();
+
+          const tx = enqueuedTransactions.find(
+            a => a.txHash === data.sourceChain?.transaction?.txHash,
+          );
+
+          if (tx) {
+            data.releaseTimestamp = tx.releaseTime;
+          }
+        }
+
         if (STATUS === "IN_PROGRESS" && isEvmTxHash) {
           const timestamp = new Date(data?.sourceChain?.timestamp);
           const now = new Date();

--- a/src/utils/txPageUtils.tsx
+++ b/src/utils/txPageUtils.tsx
@@ -62,6 +62,7 @@ export type OverviewProps = {
   redeemedAmount?: string;
   refundStatus?: string;
   refundText?: () => string;
+  releaseTimestamp?: Date;
   resultLog?: string;
   setShowOverview?: (newView: string) => void;
   showMetaMaskBtn?: boolean;


### PR DESCRIPTION
### Description

This PR adds a "Release Time" for the transaction details of transactions that have IN GOVERNORS status (when possible)

![Screenshot 2024-10-17 at 23 13 17](https://github.com/user-attachments/assets/45709627-3147-46a3-bc7c-76d2f48cf4bf)
