### PR TITLE
Add Mayan MCTP extra info

### DIFF
--- a/src/utils/mayan.ts
+++ b/src/utils/mayan.ts
@@ -1,0 +1,38 @@
+import { fetchWithTimeout } from "./asyncUtils";
+
+type MayanMctpResponse = {
+  fromTokenSymbol: string;
+  fromAmount: string;
+  toTokenSymbol: string;
+  toAmount: string;
+  fromTokenAddress: string;
+  toTokenAddress: string;
+  destAddress: string;
+  fromTokenChain: number;
+  toTokenChain: number;
+  destChain: number;
+};
+
+const getMayanMctpInfo = async (txHash: string): Promise<MayanMctpResponse> => {
+  const mayanInfo = await fetchWithTimeout(
+    `https://explorer-api.mayan.finance/v3/swap/trx/${txHash}`,
+  );
+
+  if (!mayanInfo || !mayanInfo.ok) {
+    throw new Error(
+      `Failed to fetch Mayan MCTP info for tx ${txHash}: ${
+        mayanInfo?.statusText || "Unknown error"
+      }`,
+    );
+  }
+
+  const mayanInfoJson = await mayanInfo?.json();
+
+  if (!mayanInfoJson) {
+    throw new Error(`Invalid JSON response from Mayan MCTP API for tx ${txHash}`);
+  }
+
+  return mayanInfoJson;
+};
+
+export default getMayanMctpInfo;


### PR DESCRIPTION
### Description

This PR adds logic to call Mayan endpoint for a specific configuration (Mayan MCTP where action its 1 or 3) and show all the information that we weren't showing

### Screenshots

![Screenshot 2024-11-14 at 20 36 07](https://github.com/user-attachments/assets/dd6b1a26-735d-4901-9f37-92056f25314d)
![Screenshot 2024-11-14 at 20 36 24](https://github.com/user-attachments/assets/11f49f60-3fa6-4951-a1d1-5ccfb8d57ff8)

