### PR TITLE
Pending Execution message in Progress View

### DIFF
--- a/src/pages/Tx/Information/ProgressView/index.tsx
+++ b/src/pages/Tx/Information/ProgressView/index.tsx
@@ -2,6 +2,7 @@ import { CheckCircle2, ClockIcon } from "src/icons/generic";
 import { getChainName } from "src/utils/wormhole";
 import { OverviewProps } from "src/utils/txPageUtils";
 import { getRemainingTime } from "src/utils/date";
+import { VerifyRedemption } from "../Summary/VerifyRedemption";
 import "./styles.scss";
 
 const ProgressView = ({
@@ -12,17 +13,22 @@ const ProgressView = ({
   fromChain,
   isAttestation,
   isJustGenericRelayer,
+  isJustPortalUnknown,
   isMayanOnly,
   nftInfo,
   originDateParsed,
   payloadType,
   releaseTimestamp,
+  showVerifyRedemption,
   sourceSymbol,
   sourceTokenInfo,
+  startDate,
   status,
   targetTxHash,
   toChain,
   tokenAmount,
+  txHash,
+  vaa,
 }: OverviewProps) => {
   const SOURCE_SYMBOL = sourceTokenInfo?.tokenSymbol || sourceSymbol;
 
@@ -186,6 +192,30 @@ const ProgressView = ({
             </div>
           </div>
         )}
+
+        {/* Resume transaction or show message in Progress View, only after 24 hours of pending */}
+        {status === "pending_redeem" &&
+          startDate &&
+          new Date().getTime() - new Date(startDate).getTime() >= 24 * 60 * 60 * 1000 &&
+          (showVerifyRedemption ? (
+            <span>
+              It has been more than 24 hours that this execution is pending on the destination
+              chain. You can resume your transaction{" "}
+              <VerifyRedemption
+                canTryToGetRedeem={true}
+                fromChain={fromChain}
+                isJustPortalUnknown={isJustPortalUnknown}
+                txHash={txHash}
+                vaa={vaa}
+                asText="HERE"
+              />
+            </span>
+          ) : (
+            <span>
+              We could not retrieve information about the executing transaction on the destination
+              chain at this time
+            </span>
+          ))}
       </div>
     </div>
   );

--- a/src/pages/Tx/Information/Summary/VerifyRedemption/index.tsx
+++ b/src/pages/Tx/Information/Summary/VerifyRedemption/index.tsx
@@ -4,6 +4,7 @@ import "./styles.scss";
 import { ChainId } from "@wormhole-foundation/sdk";
 
 interface Props {
+  asText?: string;
   canTryToGetRedeem: boolean;
   fromChain: ChainId | number;
   isJustPortalUnknown: boolean;
@@ -12,6 +13,7 @@ interface Props {
 }
 
 export const VerifyRedemption = ({
+  asText,
   canTryToGetRedeem,
   fromChain,
   isJustPortalUnknown,
@@ -42,6 +44,24 @@ export const VerifyRedemption = ({
       canTryToGetRedeem ? 5000 : 0,
     );
   }, [canTryToGetRedeem, vaa]);
+
+  if (asText)
+    return (
+      <a
+        className="verify-redemption-text"
+        href={
+          isJustPortalUnknown
+            ? vaa && hex
+              ? `https://www.portalbridge.com/#/redeem?vaa=${hex}`
+              : `https://www.portalbridge.com/#/redeem?sourceChain=${fromChain}&transactionId=${txHash}`
+            : `https://portalbridge.com/?sourceChain=${fromChain}&txHash=${txHash}`
+        }
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {asText}
+      </a>
+    );
 
   if (!shouldShow) return null;
 

--- a/src/pages/Tx/Information/Summary/VerifyRedemption/styles.scss
+++ b/src/pages/Tx/Information/Summary/VerifyRedemption/styles.scss
@@ -2,4 +2,9 @@
 
 .verify-redemption {
   @include button-primary;
+
+  &-text {
+    @include button-ghost;
+    display: inline-flex;
+  }
 }

--- a/src/pages/Tx/Information/Summary/index.tsx
+++ b/src/pages/Tx/Information/Summary/index.tsx
@@ -10,12 +10,12 @@ type Props = {
   foundRedeem: boolean;
   fromChain: ChainId | number;
   getRedeem: () => Promise<void>;
-  isConnect: boolean;
-  isGateway: boolean;
   isJustPortalUnknown: boolean;
   loadingRedeem: boolean;
   setShowOverview: (view: "overview" | "advanced" | "progress") => void;
   showOverview: string;
+  showVerifyRedemption: boolean;
+  startDate: Date | string;
   status: IStatus;
   txHash: string;
   vaa: string;
@@ -26,21 +26,16 @@ const Summary = ({
   foundRedeem,
   fromChain,
   getRedeem,
-  isConnect,
-  isGateway,
   isJustPortalUnknown,
   loadingRedeem,
   setShowOverview,
   showOverview,
+  showVerifyRedemption,
+  startDate,
   status,
   txHash,
   vaa,
 }: Props) => {
-  const showVerifyRedemption =
-    status === "vaa_emitted" &&
-    (isJustPortalUnknown || isConnect || isGateway) &&
-    (foundRedeem === false || (!canTryToGetRedeem && !foundRedeem));
-
   return (
     <div className="tx-information-summary">
       <ToggleGroup
@@ -64,15 +59,19 @@ const Summary = ({
           />
         )}
 
-        {showVerifyRedemption && (
-          <VerifyRedemption
-            canTryToGetRedeem={canTryToGetRedeem}
-            fromChain={fromChain}
-            isJustPortalUnknown={isJustPortalUnknown}
-            txHash={txHash}
-            vaa={vaa}
-          />
-        )}
+        {/* Resume Transaction button, only after 10 minutes */}
+        {showVerifyRedemption &&
+          startDate &&
+          new Date().getTime() - new Date(startDate).getTime() >= 60 * 10 * 1000 &&
+          (foundRedeem === false || (!canTryToGetRedeem && !foundRedeem)) && (
+            <VerifyRedemption
+              canTryToGetRedeem={canTryToGetRedeem}
+              fromChain={fromChain}
+              isJustPortalUnknown={isJustPortalUnknown}
+              txHash={txHash}
+              vaa={vaa}
+            />
+          )}
       </div>
     </div>
   );

--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -327,11 +327,10 @@ const Information = ({
   const [loadingRedeem, setLoadingRedeem] = useState(false);
   const [foundRedeem, setFoundRedeem] = useState<null | boolean>(null);
 
-  const date_30_min_before = new Date(new Date().getTime() - 30 * 60000);
+  const date_10_min_before = new Date(new Date().getTime() - 10 * 60000);
   const canTryToGetRedeem =
     (status === "external_tx" ||
-      status === "vaa_emitted" ||
-      (status === "pending_redeem" && new Date(timestamp) < date_30_min_before)) &&
+      (status === "pending_redeem" && new Date(timestamp) < date_10_min_before)) &&
     (platformToChains("Evm").includes(chainIdToChain(toChain) as any) ||
       toChain === 1 ||
       toChain === 21) &&
@@ -417,6 +416,9 @@ const Information = ({
 
   const isLatestBlockHigherThanVaaEmitBlock = lastFinalizedBlock > currentBlock;
 
+  const showVerifyRedemption =
+    status === "pending_redeem" && (isJustPortalUnknown || isConnect || isGateway);
+
   const overviewAndDetailProps = {
     action,
     amountSent,
@@ -456,12 +458,14 @@ const Information = ({
     setShowOverview,
     showMetaMaskBtn,
     showSignatures: !(appIds && appIds.includes(CCTP_MANUAL_APP_ID)),
+    showVerifyRedemption,
     sourceFee,
     sourceFeeUSD,
     sourceSymbol,
     sourceTokenChain,
     sourceTokenInfo,
     sourceTokenLink,
+    startDate,
     status,
     targetFee,
     targetFeeUSD,
@@ -485,13 +489,13 @@ const Information = ({
         foundRedeem={foundRedeem}
         fromChain={fromChain}
         getRedeem={getRedeem}
-        isConnect={isConnect}
-        isGateway={isGateway}
         isJustPortalUnknown={isJustPortalUnknown}
         loadingRedeem={loadingRedeem}
         setShowOverview={setShowOverview}
         showOverview={showOverview}
+        showVerifyRedemption={showVerifyRedemption}
         status={status}
+        startDate={startDate}
         txHash={data?.sourceChain?.transaction?.txHash}
         vaa={vaa?.raw}
       />
@@ -503,7 +507,14 @@ const Information = ({
         {showOverview === "advanced" && (
           <AdvancedView data={data} extraRawInfo={extraRawInfo} txIndex={txIndex} />
         )}
-        {showOverview === "progress" && <ProgressView {...overviewAndDetailProps} />}
+        {showOverview === "progress" && (
+          <ProgressView
+            {...overviewAndDetailProps}
+            isJustPortalUnknown={isJustPortalUnknown}
+            txHash={data?.sourceChain?.transaction?.txHash}
+            vaa={vaa?.raw}
+          />
+        )}
       </div>
     </section>
   );

--- a/src/utils/txPageUtils.tsx
+++ b/src/utils/txPageUtils.tsx
@@ -43,6 +43,7 @@ export type OverviewProps = {
   isDuplicated?: boolean;
   isGatewaySource?: boolean;
   isJustGenericRelayer?: boolean;
+  isJustPortalUnknown?: boolean;
   isLatestBlockHigherThanVaaEmitBlock?: boolean;
   isMayanOnly?: boolean;
   isUnknownApp?: boolean;
@@ -67,6 +68,7 @@ export type OverviewProps = {
   setShowOverview?: (newView: "overview" | "advanced" | "progress") => void;
   showMetaMaskBtn?: boolean;
   showSignatures?: boolean;
+  showVerifyRedemption?: boolean;
   sourceAddress?: string;
   sourceFee?: string;
   sourceFeeUSD?: string;
@@ -75,6 +77,7 @@ export type OverviewProps = {
   sourceTokenInfo?: TokenInfo;
   sourceTokenLink?: string;
   sourceTxHash?: string;
+  startDate: Date | string;
   status?: IStatus;
   targetFee?: string;
   targetFeeUSD?: string;
@@ -89,6 +92,7 @@ export type OverviewProps = {
   transactionLimit?: number;
   txHash?: string;
   txIndex?: number;
+  vaa?: string;
   VAAId?: string;
 };
 


### PR DESCRIPTION
### Description

This PR shows a message in the Progress View if it has been more than 24 hours with the status Pending Redeem. 

The text being:

- For Portal Transactions: Worholescan: "It has been more than 24 hours that this execution is pending on the destination chain. You can resume your transaction HERE"
- For non-Portal Transactions: “We could not retrieve information about the executing transaction on the destination chain at this time.” 

### Note

Since the status change from "VAA EMITTED" to "COMPLETED" for txns with redeems not supported in BW, we lost the "resume transaction" functionality.

This PR adds it back and I saw it working fine for Portal non-relayer txns (which points to advanced tools) but not for Portal relayer txns (which points to portal bridge), it seems like Connect changed/removed its deep-linking system. 

That probably should be fixed before going prod with this feature.

### Screenshots

![Screenshot 2025-01-20 at 23 23 40](https://github.com/user-attachments/assets/857517c1-3fa0-49ba-8bb1-cd733874493e)
![Screenshot 2025-01-20 at 23 37 00](https://github.com/user-attachments/assets/9ef91e62-5ea8-4490-811d-7c05b69638a2)
