### PR TITLE
Add support for source token info for WH Liquidity Layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wormscan-ui",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "private": true,
   "source": "src/index.html",
   "@parcel/resolver-default": {

--- a/src/pages/Submit/index.tsx
+++ b/src/pages/Submit/index.tsx
@@ -148,6 +148,7 @@ const SubmitYourProtocol = () => {
             a.innerHTML?.includes("recipientChain") ||
             a.innerHTML?.includes("refundChainId") ||
             a.innerHTML?.includes("targetChainId") ||
+            a.innerHTML?.includes("destinationChain") ||
             a.innerHTML?.includes("sourceChainId") ||
             a.innerHTML?.includes("destChainId") ||
             a.innerHTML?.includes("toChain") ||

--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -39,6 +39,7 @@ import {
   IManualCctpResponse,
   tryGetAddressInfo,
   tryGetWrappedToken,
+  getLiquidityLayerTokenInfo,
 } from "src/utils/cryptoToolkit";
 import { getPorticoInfo } from "src/utils/wh-portico-rpc";
 import { useRecoilState } from "recoil";
@@ -56,6 +57,7 @@ import {
   GATEWAY_APP_ID,
   GR_APP_ID,
   IStatus,
+  LIQUIDITY_LAYER_APP_ID,
   MAYAN_MCTP_APP_ID,
   NTT_APP_ID,
   PORTAL_APP_ID,
@@ -122,7 +124,7 @@ const Tx = () => {
   const { data: chainLimitsData, isLoading: isLoadingLimits } = useQuery(["getLimit"], () =>
     getClient()
       .governor.getLimit()
-      .catch(() => null),
+      .catch((): null => null),
   );
 
   const cancelRequests = useRef(false);
@@ -275,7 +277,7 @@ const Tx = () => {
           }
           return null;
         })
-        .catch(() => {
+        .catch((): null => {
           return null;
         });
 
@@ -294,7 +296,7 @@ const Tx = () => {
           }
           return null;
         })
-        .catch(() => {
+        .catch((): null => {
           return null;
         });
 
@@ -331,19 +333,18 @@ const Tx = () => {
             let solanaResponse: IManualCctpResponse | null;
             let suiResponse: IManualCctpResponse | null;
             let aptosResponse: IManualCctpResponse | null;
-
             if (canBeSolanaTxHash) {
-              solanaResponse = await getSolanaCctp(network, txHash).catch(() => null);
+              solanaResponse = await getSolanaCctp(network, txHash).catch((): null => null);
               suiResponse = solanaResponse
                 ? null
-                : await getSuiCctp(network, txHash).catch(() => null);
+                : await getSuiCctp(network, txHash).catch((): null => null);
               aptosResponse = null;
             }
 
             if (isEvmTxHash) {
               solanaResponse = null;
               suiResponse = null;
-              aptosResponse = await getAptosCctp(network, txHash).catch(() => null);
+              aptosResponse = await getAptosCctp(network, txHash).catch((): null => null);
             }
 
             const resp: IManualCctpResponse = solanaResponse || suiResponse || aptosResponse;
@@ -664,6 +665,47 @@ const Tx = () => {
               network,
               data.content?.standarizedProperties?.toChain as ChainId,
             );
+          }
+        }
+        // ----
+
+        // check Wormhole Liquidity Layer
+        if (data?.content?.standarizedProperties?.appIds?.includes(LIQUIDITY_LAYER_APP_ID)) {
+          if (data.content.payload?.payloadId === 11) {
+            const liquidityLayerTokenInfo = await getLiquidityLayerTokenInfo(
+              network,
+              data.sourceChain?.transaction?.txHash,
+              data.sourceChain?.chainId,
+            );
+
+            if (liquidityLayerTokenInfo) {
+              if (liquidityLayerTokenInfo.type === "SwapAndForwardedEth") {
+                data.data = {
+                  symbol:
+                    network === "Testnet"
+                      ? testnetNativeCurrencies[chainIdToChain(data.sourceChain?.chainId)]
+                      : mainnetNativeCurrencies[chainIdToChain(data.sourceChain?.chainId)],
+                  tokenAmount: String(+liquidityLayerTokenInfo.amountIn / 10 ** 18),
+                  usdAmount: "",
+                };
+              }
+
+              if (
+                liquidityLayerTokenInfo.type === "ForwardedERC20" ||
+                liquidityLayerTokenInfo.type === "SwapAndForwardedERC20"
+              ) {
+                data.data = {
+                  symbol: liquidityLayerTokenInfo.symbol,
+                  tokenAmount: String(
+                    +liquidityLayerTokenInfo.amountIn / 10 ** liquidityLayerTokenInfo.decimals,
+                  ),
+                  usdAmount: "",
+                };
+
+                data.content.standarizedProperties.tokenAddress = liquidityLayerTokenInfo.token;
+                data.content.standarizedProperties.tokenChain = data.sourceChain?.chainId;
+              }
+            }
           }
         }
         // ----
@@ -1197,7 +1239,7 @@ const Tx = () => {
         }
         // ----
 
-        // check Mayan
+        // check Mayan MCTP
         if (data?.content?.standarizedProperties?.appIds?.includes(MAYAN_MCTP_APP_ID)) {
           if (data?.content?.payload?.action === 1 || data?.content?.payload?.action === 3) {
             try {

--- a/src/pages/VaaParser/index.tsx
+++ b/src/pages/VaaParser/index.tsx
@@ -123,6 +123,7 @@ const VaaParser = () => {
             a.innerHTML?.includes("recipientChain") ||
             a.innerHTML?.includes("refundChainId") ||
             a.innerHTML?.includes("targetChainId") ||
+            a.innerHTML?.includes("destinationChain") ||
             a.innerHTML?.includes("sourceChainId") ||
             a.innerHTML?.includes("destChainId") ||
             a.innerHTML?.includes("toChain") ||

--- a/src/utils/cryptoToolkit.ts
+++ b/src/utils/cryptoToolkit.ts
@@ -57,6 +57,23 @@ interface IGeckoTokenInfoResponse {
   };
 }
 
+interface ILiquidityLayerTokenInfoResponse {
+  type:
+    | "ForwardedERC20"
+    | "SwapAndForwardedERC20"
+    | "SwapAndForwardedEth"
+    | "SwapAndForwardedERC20";
+  token?: string;
+  amountIn?: string;
+  swapProtocol?: string;
+  middleToken?: string;
+  middleAmount?: string;
+  mayanProtocol?: string;
+  mayanData?: string;
+  symbol?: string;
+  decimals?: number;
+}
+
 const BFF_URL = process.env.WORMSCAN_BFF_URL;
 
 export const getGeckoTokenInfo = async (
@@ -72,6 +89,24 @@ export const getGeckoTokenInfo = async (
       ?.data as IGeckoTokenInfoResponse;
 
     return geckoTokenInfoResponse;
+  } catch (e) {
+    return null;
+  }
+};
+
+export const getLiquidityLayerTokenInfo = async (
+  network: Network,
+  txHash: string,
+  chainId: ChainId,
+) => {
+  try {
+    const liquidityLayerTokenInfoRequest = await fetchWithTimeout(
+      `${BFF_URL}/fastTransfers/getInfo?network=${network}&txHash=${txHash}&chainId=${chainId}`,
+    );
+
+    const liquidityLayerTokenInfoResponse =
+      (await liquidityLayerTokenInfoRequest.json()) as ILiquidityLayerTokenInfoResponse;
+    return liquidityLayerTokenInfoResponse;
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
### Description

This PR adds a check for Wormhole Liquidity Layer transactions (those with payloadId = 11) so the token and the amount can be shown

![screencapture-localhost-1234-2025-02-06-16_34_32](https://github.com/user-attachments/assets/6f0de84d-e632-4ee3-a3d3-a4f8824fec98)
