### PR TITLE
Add more Mayan Shuttle support

### DIFF
--- a/src/api/guardian-network/types.ts
+++ b/src/api/guardian-network/types.ts
@@ -316,7 +316,7 @@ export interface GetOperationsOutput {
       fee?: string;
       fromAddress?: string | null;
       parsedPayload?: any;
-      payload?: string;
+      payload?: any;
       payloadId?: number;
       payloadType?: number;
       toAddress?: string;

--- a/src/pages/Tx/Information/Overview/index.tsx
+++ b/src/pages/Tx/Information/Overview/index.tsx
@@ -99,6 +99,7 @@ const Overview = ({
   resultLog,
   setShowOverview,
   showMetaMaskBtn,
+  showMinReceivedTooltip,
   showSignatures,
   sourceAddress,
   sourceFee,
@@ -909,6 +910,23 @@ const Overview = ({
                         chainId={toChain ? toChain : 0}
                         network={currentNetwork}
                       />
+                    )}
+                    {showMinReceivedTooltip && (
+                      <Tooltip
+                        type="info"
+                        tooltip={
+                          <div>
+                            <p>
+                              This is the minimum amount of tokens that will be received. Actual
+                              value can be higher
+                            </p>
+                          </div>
+                        }
+                      >
+                        <span>
+                          <InfoCircleIcon />
+                        </span>
+                      </Tooltip>
                     )}
                     {!!showMetaMaskBtn && (
                       <AddToMetaMaskBtn

--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -15,6 +15,7 @@ import {
   ETH_BRIDGE_APP_ID,
   GATEWAY_APP_ID,
   GR_APP_ID,
+  LIQUIDITY_LAYER_APP_ID,
   MAYAN_APP_ID,
   PORTAL_APP_ID,
   txType,
@@ -36,6 +37,7 @@ import AdvancedView from "./AdvancedView";
 import ProgressView from "./ProgressView";
 import Summary from "./Summary";
 import "./styles.scss";
+import { OverviewProps } from "src/utils/txPageUtils";
 
 interface Props {
   blockData: GetBlockData;
@@ -419,7 +421,12 @@ const Information = ({
   const showVerifyRedemption =
     status === "pending_redeem" && (isJustPortalUnknown || isConnect || isGateway);
 
-  const overviewAndDetailProps = {
+  const showMinReceivedTooltip = !!(
+    data.content?.standarizedProperties?.appIds?.includes(LIQUIDITY_LAYER_APP_ID) &&
+    data.content?.payload?.payload?.parsedRedeemerMessage?.outputToken?.swap?.limitAmount
+  );
+
+  const overviewAndDetailProps: OverviewProps = {
     action,
     amountSent,
     amountSentUSD,
@@ -459,6 +466,7 @@ const Information = ({
     showMetaMaskBtn,
     showSignatures: !(appIds && appIds.includes(CCTP_MANUAL_APP_ID)),
     showVerifyRedemption,
+    showMinReceivedTooltip,
     sourceFee,
     sourceFeeUSD,
     sourceSymbol,

--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -9,6 +9,7 @@ import {
   chainToChainId,
   toChainId,
   chainIdToChain,
+  UniversalAddress,
 } from "@wormhole-foundation/sdk";
 import { useEnvironment } from "src/context/EnvironmentContext";
 import { Loader } from "src/components/atoms";
@@ -728,6 +729,48 @@ const Tx = () => {
                 data.content.standarizedProperties.overwriteRedeemAmount = String(
                   +receivedAmount / 10 ** targetToken.tokenDecimals,
                 );
+              }
+            }
+          }
+        }
+
+        if (data?.content?.standarizedProperties?.appIds?.includes(LIQUIDITY_LAYER_APP_ID)) {
+          if (
+            data.content.payload?.payload?.payloadId === 1 &&
+            data.content.payload?.payload?.parsedRedeemerMessage?.outputToken?.address
+          ) {
+            const outputTokenAddress =
+              data.content.payload?.payload?.parsedRedeemerMessage?.outputToken?.address;
+
+            console.log({ outputTokenAddress });
+
+            const targetTokenAddress = new UniversalAddress(outputTokenAddress)
+              .toNative(chainIdToChain(data.content.standarizedProperties?.toChain))
+              ?.toString();
+
+            console.log({ targetTokenAddress });
+
+            const targetTokenInfo = await getTokenInformation(
+              data.content.standarizedProperties?.toChain,
+              environment,
+              targetTokenAddress,
+            );
+
+            if (targetTokenInfo) {
+              data.content.standarizedProperties.overwriteTargetTokenAddress = targetTokenAddress;
+              data.content.standarizedProperties.overwriteTargetSymbol = targetTokenInfo.symbol;
+              data.content.standarizedProperties.overwriteTargetTokenChain =
+                data.content.standarizedProperties?.toChain;
+
+              if (
+                targetTokenInfo.tokenDecimals &&
+                data.content.payload?.payload?.parsedRedeemerMessage?.outputToken?.swap?.limitAmount
+              ) {
+                data.content.standarizedProperties.overwriteRedeemAmount = `${
+                  +data.content.payload?.payload?.parsedRedeemerMessage?.outputToken?.swap
+                    ?.limitAmount /
+                  10 ** targetTokenInfo.tokenDecimals
+                }`;
               }
             }
           }

--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -742,13 +742,9 @@ const Tx = () => {
             const outputTokenAddress =
               data.content.payload?.payload?.parsedRedeemerMessage?.outputToken?.address;
 
-            console.log({ outputTokenAddress });
-
             const targetTokenAddress = new UniversalAddress(outputTokenAddress)
               .toNative(chainIdToChain(data.content.standarizedProperties?.toChain))
               ?.toString();
-
-            console.log({ targetTokenAddress });
 
             const targetTokenInfo = await getTokenInformation(
               data.content.standarizedProperties?.toChain,

--- a/src/utils/txPageUtils.tsx
+++ b/src/utils/txPageUtils.tsx
@@ -67,6 +67,7 @@ export type OverviewProps = {
   resultLog?: string;
   setShowOverview?: (newView: "overview" | "advanced" | "progress") => void;
   showMetaMaskBtn?: boolean;
+  showMinReceivedTooltip?: boolean;
   showSignatures?: boolean;
   showVerifyRedemption?: boolean;
   sourceAddress?: string;


### PR DESCRIPTION
### Description

This PR adds more support for **Mayan Shuttle + Wormhole Liquidity Layer** transactions.

- For those with `payloadId = 1` that contain target token information, the correct target token and amount will be shown.

![PR](https://github.com/user-attachments/assets/46ce6218-8c87-4cfc-9bb2-e1877a4aa699)

