### PR TITLE
Wormhole Settlements fixes

### DIFF
--- a/src/components/atoms/ProtocolIcon/index.tsx
+++ b/src/components/atoms/ProtocolIcon/index.tsx
@@ -4,11 +4,9 @@ import {
   CCTP_APP_ID,
   CONNECT_APP_ID,
   ETH_BRIDGE_APP_ID,
-  FAST_TRANSFERS_APP_ID,
   FOLKS_FINANCE_APP_ID,
   GATEWAY_APP_ID,
   GR_APP_ID,
-  LIQUIDITY_LAYER_APP_ID,
   M_PORTAL_APP_ID,
   MAYAN_APP_ID,
   MAYAN_MCTP_APP_ID,
@@ -21,6 +19,7 @@ import {
   SYNONYM_APP_ID,
   TBTC_APP_ID,
   USDT_TRANSFER_APP_ID,
+  WORMHOLE_SETTLEMENTS_APP_ID,
 } from "src/consts";
 
 const ProtocolIcon = ({ protocol, width = 28 }: { protocol: string; width?: number }) => {
@@ -572,7 +571,7 @@ const iconMap: Record<string, React.FC<{ width: number }>> = {
   [FOLKS_FINANCE_APP_ID]: FolksFinanceIcon,
   [GATEWAY_APP_ID]: WormholeGatewayIcon,
   [GR_APP_ID]: StandardRelayerIcon,
-  [LIQUIDITY_LAYER_APP_ID]: WormholeLiquidityLayerIcon,
+  [WORMHOLE_SETTLEMENTS_APP_ID]: WormholeLiquidityLayerIcon,
   [M_PORTAL_APP_ID]: MPortalIcon,
   [MAYAN_APP_ID]: MayanIcon,
   [MAYAN_MCTP_APP_ID]: MayanIcon,
@@ -587,6 +586,6 @@ const iconMap: Record<string, React.FC<{ width: number }>> = {
   [USDT_TRANSFER_APP_ID]: USDTTransferIcon,
 };
 
-const genericIcons = [FAST_TRANSFERS_APP_ID];
+const genericIcons = [WORMHOLE_SETTLEMENTS_APP_ID];
 
 export default ProtocolIcon;

--- a/src/components/atoms/ProtocolIcon/index.tsx
+++ b/src/components/atoms/ProtocolIcon/index.tsx
@@ -586,6 +586,6 @@ const iconMap: Record<string, React.FC<{ width: number }>> = {
   [USDT_TRANSFER_APP_ID]: USDTTransferIcon,
 };
 
-const genericIcons = [WORMHOLE_SETTLEMENTS_APP_ID];
+const genericIcons: string[] = [];
 
 export default ProtocolIcon;

--- a/src/components/molecules/ProtocolsStats/index.tsx
+++ b/src/components/molecules/ProtocolsStats/index.tsx
@@ -6,18 +6,17 @@ import {
   CCTP_APP_ID,
   CONNECT_APP_ID,
   ETH_BRIDGE_APP_ID,
-  FAST_TRANSFERS_APP_ID,
   GATEWAY_APP_ID,
   GR_APP_ID,
-  LIQUIDITY_LAYER_APP_ID,
   MAYAN_APP_ID,
+  MAYAN_SHUTTLE_APP_ID,
   NTT_APP_ID,
   OMNISWAP_APP_ID,
   PORTAL_APP_ID,
-  SWAP_LAYER_APP_ID,
   TBTC_APP_ID,
   UNKNOWN_APP_ID,
   USDT_TRANSFER_APP_ID,
+  WORMHOLE_SETTLEMENTS_APP_ID,
 } from "src/consts";
 import { useEnvironment } from "src/context/EnvironmentContext";
 import { Cube3DIcon, InfoCircleIcon, LinkIcon } from "src/icons/generic";
@@ -39,14 +38,13 @@ const protocolMapping: Record<string, string> = {
   cctp: CCTP_APP_ID,
   connect: CONNECT_APP_ID,
   eth_bridge: ETH_BRIDGE_APP_ID,
-  fast_transfers: FAST_TRANSFERS_APP_ID,
-  liquidity_layer: LIQUIDITY_LAYER_APP_ID,
+  wormhole_settlements: WORMHOLE_SETTLEMENTS_APP_ID,
+  mayan_shuttle: MAYAN_SHUTTLE_APP_ID,
   mayan: MAYAN_APP_ID,
   native_token_transfer: NTT_APP_ID,
   omniswap: OMNISWAP_APP_ID,
   portal_token_bridge: PORTAL_APP_ID,
   standard_relayer: GR_APP_ID,
-  swap_layer: SWAP_LAYER_APP_ID,
   tbtc: TBTC_APP_ID,
   usdt_transfer: USDT_TRANSFER_APP_ID,
   wormchain_gateway_transfer: GATEWAY_APP_ID,
@@ -75,6 +73,10 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
             item =>
               item.protocol !== C3_APP_ID &&
               item.protocol !== CONNECT_APP_ID &&
+              item.protocol !== WORMHOLE_SETTLEMENTS_APP_ID &&
+              item.protocol !== MAYAN_SHUTTLE_APP_ID &&
+              item.protocol !== "SWAP_LAYER" &&
+              item.protocol !== "FAST_TRANSFERS" &&
               item.protocol !== "STABLE" &&
               item.protocol !== "WORMHOLE_GATEWAY_TRANSFER",
           )
@@ -145,7 +147,6 @@ const ProtocolsStats = ({ numberOfProtocols }: { numberOfProtocols?: number }) =
             data?.length > 0 &&
             data?.map((item, i) => {
               if (i >= numberOfProtocols) return null;
-              if (item.protocol === "WORMHOLE_LIQUIDITY_LAYER") return null;
 
               return (
                 <div

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -199,6 +199,7 @@ export const GR_APP_ID = "GENERIC_RELAYER";
 export const M_PORTAL_APP_ID = "M_PORTAL";
 export const MAYAN_APP_ID = "MAYAN";
 export const MAYAN_MCTP_APP_ID = "MAYAN_MCTP";
+export const MAYAN_SHUTTLE_APP_ID = "MAYAN_SHUTTLE";
 export const MAYAN_SWIFT_APP_ID = "MAYAN_SWIFT";
 export const NTT_APP_ID = "NATIVE_TOKEN_TRANSFER";
 export const OMNISWAP_APP_ID = "OMNISWAP";
@@ -206,17 +207,9 @@ export const PORTAL_APP_ID = "PORTAL_TOKEN_BRIDGE";
 export const PORTAL_NFT_APP_ID = "PORTAL_NFT_BRIDGE";
 export const SYNONYM_APP_ID = "SYNONYM";
 export const TBTC_APP_ID = "TBTC";
-export const USDT_TRANSFER_APP_ID = "USDT_TRANSFER";
 export const UNKNOWN_APP_ID = "UNKNOWN";
-
-// This two (fast transfers & swap layer) are being swapped to liquidity
-// layer and mayan shuttle. If changed in vaa-parser, we need to remove
-// patch logic by removing FAST_TRANSFER_APP_ID and SWAP_LAYER_APP_ID
-// in all their occurrences in the codebase.
-export const FAST_TRANSFERS_APP_ID = "FAST_TRANSFERS";
-export const SWAP_LAYER_APP_ID = "SWAP_LAYER";
-export const LIQUIDITY_LAYER_APP_ID = "WORMHOLE_LIQUIDITY_LAYER";
-export const MAYAN_SHUTTLE_APP_ID = "MAYAN_SHUTTLE";
+export const USDT_TRANSFER_APP_ID = "USDT_TRANSFER";
+export const WORMHOLE_SETTLEMENTS_APP_ID = "WORMHOLE_SETTLEMENTS";
 
 const targetChainsSupportedMainnet: { [key: string]: ChainId[] } = {
   [PORTAL_APP_ID]: [

--- a/src/pages/Tx/Information/index.tsx
+++ b/src/pages/Tx/Information/index.tsx
@@ -15,7 +15,7 @@ import {
   ETH_BRIDGE_APP_ID,
   GATEWAY_APP_ID,
   GR_APP_ID,
-  LIQUIDITY_LAYER_APP_ID,
+  WORMHOLE_SETTLEMENTS_APP_ID,
   MAYAN_APP_ID,
   PORTAL_APP_ID,
   txType,
@@ -429,7 +429,7 @@ const Information = ({
     status === "pending_redeem" && (isJustPortalUnknown || isConnect || isGateway);
 
   const showMinReceivedTooltip = !!(
-    data.content?.standarizedProperties?.appIds?.includes(LIQUIDITY_LAYER_APP_ID) &&
+    data.content?.standarizedProperties?.appIds?.includes(WORMHOLE_SETTLEMENTS_APP_ID) &&
     data.content?.payload?.payload?.parsedRedeemerMessage?.outputToken?.swap?.limitAmount
   );
 

--- a/src/pages/Tx/index.tsx
+++ b/src/pages/Tx/index.tsx
@@ -59,9 +59,8 @@ import {
   GATEWAY_APP_ID,
   GR_APP_ID,
   IStatus,
-  LIQUIDITY_LAYER_APP_ID,
   MAYAN_MCTP_APP_ID,
-  MAYAN_SHUTTLE_APP_ID,
+  WORMHOLE_SETTLEMENTS_APP_ID,
   NTT_APP_ID,
   PORTAL_APP_ID,
   PORTAL_NFT_APP_ID,
@@ -683,7 +682,7 @@ const Tx = () => {
 
         // check Wormhole Liquidity Layer
         if (
-          data?.content?.standarizedProperties?.appIds?.includes(LIQUIDITY_LAYER_APP_ID) &&
+          data?.content?.standarizedProperties?.appIds?.includes(WORMHOLE_SETTLEMENTS_APP_ID) &&
           data.content.payload?.payloadId === 11
         ) {
           const liquidityLayerTokenInfo = await getLiquidityLayerTokenInfo(
@@ -743,7 +742,7 @@ const Tx = () => {
           }
         }
 
-        if (data?.content?.standarizedProperties?.appIds?.includes(LIQUIDITY_LAYER_APP_ID)) {
+        if (data?.content?.standarizedProperties?.appIds?.includes(WORMHOLE_SETTLEMENTS_APP_ID)) {
           if (
             data.content.payload?.payload?.payloadId === 1 &&
             data.content.payload?.payload?.parsedRedeemerMessage?.outputToken?.address

--- a/src/utils/filterUtils.tsx
+++ b/src/utils/filterUtils.tsx
@@ -28,15 +28,13 @@ import {
   OMNISWAP_URL,
   C3_URL,
   GATEWAY_URL,
-  SWAP_LAYER_APP_ID,
-  FAST_TRANSFERS_APP_ID,
   TBTC_URL,
   GR_URL,
   MAYAN_SHUTTLE_APP_ID,
-  LIQUIDITY_LAYER_APP_ID,
   SYNONYM_APP_ID,
   SYNONYM_URL,
   FOLKS_FINANCE_APP_ID,
+  WORMHOLE_SETTLEMENTS_APP_ID,
 } from "src/consts";
 
 const appIds = [
@@ -66,16 +64,6 @@ export const PROTOCOL_LIST: { label: string; value: string }[] = [
     label: formatAppId(appId),
     value: String(appId),
   })),
-  // {
-  //   icon: <ProtocolIcon protocol={MAYAN_SHUTTLE_APP_ID} />,
-  //   label: "Mayan Shuttle",
-  //   value: SWAP_LAYER_APP_ID,
-  // },
-  // {
-  //   icon: <ProtocolIcon protocol={LIQUIDITY_LAYER_APP_ID} />,
-  //   label: "Wormhole Liquidity Layer",
-  //   value: FAST_TRANSFERS_APP_ID,
-  // },
 ].sort((a, b) => a.label.localeCompare(b.label));
 
 export const ChainFilterMainnet = [
@@ -227,7 +215,7 @@ export const chainsSupportedByProtocol: Record<string, ChainId[]> = {
     chainToChainId("Optimism"),
     chainToChainId("Polygon"),
   ],
-  [LIQUIDITY_LAYER_APP_ID]: [
+  [WORMHOLE_SETTLEMENTS_APP_ID]: [
     chainToChainId("Arbitrum"),
     chainToChainId("Bsc"),
     chainToChainId("Solana"),
@@ -315,7 +303,7 @@ export const chainsSupportedByProtocol: Record<string, ChainId[]> = {
     chainToChainId("Terra2"),
     chainToChainId("Xpla"),
   ],
-  [SWAP_LAYER_APP_ID]: [chainToChainId("Ethereum")],
+  [MAYAN_SHUTTLE_APP_ID]: [chainToChainId("Ethereum")],
   [TBTC_APP_ID]: [
     chainToChainId("Arbitrum"),
     chainToChainId("Base"),


### PR DESCRIPTION
### Description

This PR deletes all the patching logic that we had to rename FAST_TRANSFERS to WORMHOLE_LIQUIDITY_LAYER and SWAP_LAYER to MAYAN_SHUTTLE

Now, they are called "Wormhole Settlements" and "Mayan Shuttle" and come like that directly from API.